### PR TITLE
Feature/autenticao endpoints

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -5,12 +5,14 @@ from rest_framework.response import Response
 
 from api.models import Entidade, Dado
 from api.serializers import EntidadeSerializer, DadoSerializer
+from login.decorators import auth_required
 
 
 class EntidadeView(GenericAPIView):
     serializer_class = EntidadeSerializer
     queryset = Entidade.objects.all()
 
+    @auth_required
     def get(self, request, *args, **kwargs):
         obj = get_object_or_404(
             self.queryset,
@@ -27,6 +29,7 @@ class DadoView(RetrieveAPIView):
     serializer_class = DadoSerializer
     queryset = Dado.objects.all()
 
+    @auth_required
     def get(self, request, *args, **kwargs):
         obj = get_object_or_404(
             self.queryset,


### PR DESCRIPTION
Nessa branch os métodos que recebem as requisições GET foram decorados com a função **auth_required**.

Desde modo, as requisições para os endpoints precisam enviar um parâmtro **auth_token** na querystring. Exemplo:

```bash
 - GET /api/EST/33?auth_token=aef311223....
```

Caso a verificação do token falhe a resposta terá **status 403**