### PR TITLE
Feature/admin save cache

### DIFF
--- a/lupa/admin.py
+++ b/lupa/admin.py
@@ -23,10 +23,6 @@ from .models import (
     ColunaDetalhe,
     ColunaMapa,
 )
-from lupa.serializers import (
-    EntidadeSerializer,
-    DadoEntidadeSerializer,
-    DadoDetalheSerializer)
 from lupa.tasks import (
     asynch_repopulate_cache_entity,
     asynch_repopulate_cache_data_entity,
@@ -42,7 +38,6 @@ def remove_entity_from_cache(modeladmin, request, queryset):
     proc2 = asynch_repopulate_cache_entity.si(
         key_prefix,
         queryset,
-        EntidadeSerializer
     )
     flow = chain(proc1, proc2)
     flow.delay()
@@ -60,7 +55,8 @@ def remove_data_from_cache(modeladmin, request, queryset):
     )
 
     proc2 = asynch_repopulate_cache_data_entity.si(
-        entity_key_prefix, queryset, DadoEntidadeSerializer
+        entity_key_prefix,
+        queryset
     )
 
     flow = chain(proc1, proc2)
@@ -82,7 +78,6 @@ def remove_data_from_cache(modeladmin, request, queryset):
     proc2 = asynch_repopulate_cache_data_detail.si(
         detail_key_prefix,
         detail_queryset,
-        DadoDetalheSerializer,
     )
 
     flow = chain(proc1, proc2)

--- a/lupa/admin.py
+++ b/lupa/admin.py
@@ -41,6 +41,10 @@ def remove_entity_from_cache(modeladmin, request, queryset):
     )
     flow = chain(proc1, proc2)
     flow.delay()
+    messages.success(
+        request,
+        'Seu pedido de renovação de cache foi recebido e será processado'
+    )
 
 
 def remove_data_from_cache(modeladmin, request, queryset):
@@ -83,6 +87,11 @@ def remove_data_from_cache(modeladmin, request, queryset):
     flow = chain(proc1, proc2)
 
     flow.delay()
+
+    messages.success(
+        request,
+        'Seu pedido de renovação de cache foi recebido e será processado'
+    )
 
 
 remove_data_from_cache.short_description = 'Renovar o cache'

--- a/lupa/cache.py
+++ b/lupa/cache.py
@@ -168,6 +168,9 @@ def repopulate_cache(key_prefix, entities, queryset, serializer):
                 )
                 django_cache.set(key, json_data, timeout=obj.cache_timeout_sec)
                 obj.last_cache_update = dt.date.today()
+                # Set is_cacheable = True to avoid problems with the asynch
+                # calls performed the 'save' method from obj
+                obj.is_cacheable = True
                 obj.save()
 
 

--- a/lupa/cache.py
+++ b/lupa/cache.py
@@ -93,26 +93,29 @@ def custom_cache(key_prefix, model_kwargs=dict()):
     return _custom_cache
 
 
-def _repopulate_cache_entity(key_prefix, queryset, serializer):
+def _repopulate_cache_entity(key_prefix, queryset):
+    from lupa.serializers import EntidadeSerializer
     entities = queryset.distinct('abreviation').order_by('abreviation')
-    repopulate_cache(key_prefix, entities, queryset, serializer)
+    repopulate_cache(key_prefix, entities, queryset, EntidadeSerializer)
 
 
-def _repopulate_cache_data_entity(key_prefix, queryset, serializer):
+def _repopulate_cache_data_entity(key_prefix, queryset):
+    from lupa.serializers import DadoEntidadeSerializer
     entities = queryset.distinct('entity_type__abreviation').order_by(
         'entity_type__abreviation'
     )
     entities = [e.entity_type for e in entities]
-    repopulate_cache(key_prefix, entities, queryset, serializer)
+    repopulate_cache(key_prefix, entities, queryset, DadoEntidadeSerializer)
 
 
-def _repopulate_cache_data_detail(key_prefix, queryset, serializer):
+def _repopulate_cache_data_detail(key_prefix, queryset):
+    from lupa.serializers import DadoDetalheSerializer
     entities = queryset.distinct(
         'dado_main__entity_type__abreviation').order_by(
             'dado_main__entity_type__abreviation'
     )
     entities = [e.dado_main.entity_type for e in entities]
-    repopulate_cache(key_prefix, entities, queryset, serializer)
+    repopulate_cache(key_prefix, entities, queryset, DadoDetalheSerializer)
 
 
 def _stderr(entity, domain_id):

--- a/lupa/models.py
+++ b/lupa/models.py
@@ -310,18 +310,17 @@ class Entidade(models.Model):
             old = queryset.get(pk=self.pk)
             new = self
 
-            key_prefix = ENTITY_KEY_PREFIX
             # Check if is_cacheable was updated
             if old.is_cacheable and not new.is_cacheable:
                 model_args = ['abreviation']
                 asynch_remove_from_cache.delay(
-                    key_prefix,
+                    ENTITY_KEY_PREFIX,
                     model_args,
                     queryset
                 )
             elif not old.is_cacheable and new.is_cacheable:
                 asynch_repopulate_cache_entity.delay(
-                    key_prefix,
+                    ENTITY_KEY_PREFIX,
                     queryset,
                 )
         except ObjectDoesNotExist:

--- a/lupa/tasks.py
+++ b/lupa/tasks.py
@@ -9,18 +9,18 @@ from mprj_api.celeryconfig import app
 
 
 @app.task
-def asynch_repopulate_cache_entity(key_prefix, queryset, serializer):
-    _repopulate_cache_entity(key_prefix, queryset, serializer)
+def asynch_repopulate_cache_entity(key_prefix, queryset):
+    _repopulate_cache_entity(key_prefix, queryset)
 
 
 @app.task
-def asynch_repopulate_cache_data_entity(key_prefix, queryset, serializer):
-    _repopulate_cache_data_entity(key_prefix, queryset, serializer)
+def asynch_repopulate_cache_data_entity(key_prefix, queryset):
+    _repopulate_cache_data_entity(key_prefix, queryset)
 
 
 @app.task
-def asynch_repopulate_cache_data_detail(key_prefix, queryset, serializer):
-    _repopulate_cache_data_detail(key_prefix, queryset, serializer)
+def asynch_repopulate_cache_data_detail(key_prefix, queryset):
+    _repopulate_cache_data_detail(key_prefix, queryset)
 
 
 @app.task

--- a/lupa/tests/test_admin.py
+++ b/lupa/tests/test_admin.py
@@ -4,9 +4,6 @@ from unittest import TestCase, mock
 from lupa.admin import remove_data_from_cache, remove_entity_from_cache
 from lupa.models import DadoEntidade, DadoDetalhe
 from lupa.admin import DadoEntidadeAdmin
-from lupa.serializers import (EntidadeSerializer,
-                              DadoEntidadeSerializer,
-                              DadoDetalheSerializer)
 import pytest
 
 
@@ -170,7 +167,6 @@ class ClearFromCache(TestCase):
         asynch_rep_data_entity.si.assert_called_once_with(
             entity_key_prefix,
             queryset,
-            DadoEntidadeSerializer
         )
         self.assertEqual(_chain.call_args_list[0][0][0], asynch_remove.si())
         self.assertEqual(
@@ -245,14 +241,9 @@ class ClearFromCache(TestCase):
             asynch_rep_cache_data_entity.si.call_args_list[0][0][1],
             queryset
         )
-        self.assertEqual(
-            asynch_rep_cache_data_entity.si.call_args_list[0][0][2],
-            DadoEntidadeSerializer
-        )
         asynch_rep_cache_data_entity.si.assert_called_once_with(
             key_prefix_entidade,
             queryset,
-            DadoEntidadeSerializer
         )
         call_args = asynch_rep_cache_data_detail.si.call_args_list[0][0]
         self.assertEqual(call_args[0], key_prefix_detalhe)
@@ -260,7 +251,6 @@ class ClearFromCache(TestCase):
             list(call_args[1].values_list('id')),
             expected_queryset
         )
-        self.assertEqual(call_args[2], DadoDetalheSerializer)
         self.assertEqual(
             _chain.call_args_list[0][0][0],
             asynch_remove_data.si()
@@ -310,7 +300,6 @@ class ClearFromCache(TestCase):
         asynch_rep_cache.si.assert_called_once_with(
             key_prefix,
             queryset,
-            EntidadeSerializer
         )
         _chain.assert_called_once_with(
             asynch_remove.si(),

--- a/lupa/tests/test_admin.py
+++ b/lupa/tests/test_admin.py
@@ -109,6 +109,7 @@ class TestMoveDadoToPosition(TestCase):
 
 @pytest.mark.django_db(transaction=True)
 class ClearFromCache(TestCase):
+    @mock.patch('lupa.admin.messages')
     @mock.patch('lupa.admin.chain')
     @mock.patch('lupa.admin.asynch_repopulate_cache_data_detail')
     @mock.patch('lupa.admin.asynch_repopulate_cache_data_entity')
@@ -117,7 +118,8 @@ class ClearFromCache(TestCase):
                                    asynch_remove,
                                    asynch_rep_data_entity,
                                    asynch_rep_data_detail,
-                                   _chain):
+                                   _chain,
+                                   _msgs):
 
         flow_mock = mock.MagicMock()
         _chain.return_value = flow_mock
@@ -173,7 +175,12 @@ class ClearFromCache(TestCase):
             _chain.call_args_list[0][0][1], asynch_rep_data_entity.si()
         )
         flow_mock.delay.assert_has_calls([mock.call(), mock.call()])
+        _msgs.success.assert_called_once_with(
+            request,
+            'Seu pedido de renovação de cache foi recebido e será processado'
+        )
 
+    @mock.patch('lupa.admin.messages')
     @mock.patch('lupa.admin.chain')
     @mock.patch('lupa.admin.asynch_repopulate_cache_data_detail')
     @mock.patch('lupa.admin.asynch_repopulate_cache_data_entity')
@@ -183,7 +190,8 @@ class ClearFromCache(TestCase):
         asynch_remove_data,
         asynch_rep_cache_data_entity,
         asynch_rep_cache_data_detail,
-        _chain
+        _chain,
+        _msgs
     ):
 
         flow_mock = mock.MagicMock()
@@ -268,12 +276,17 @@ class ClearFromCache(TestCase):
             asynch_rep_cache_data_detail.si()
         )
         flow_mock.delay.assert_has_calls([mock.call(), mock.call()])
+        _msgs.success.assert_called_once_with(
+            request,
+            'Seu pedido de renovação de cache foi recebido e será processado'
+        )
 
+    @mock.patch('lupa.admin.messages')
     @mock.patch('lupa.admin.chain')
     @mock.patch('lupa.admin.asynch_repopulate_cache_entity')
     @mock.patch('lupa.admin.asynch_remove_from_cache')
     def test_clear_entity_from_cache(self, asynch_remove, asynch_rep_cache,
-                                     _chain):
+                                     _chain, _msgs):
         flow_mock = mock.MagicMock()
         _chain.return_value = flow_mock
         modeladmin = None
@@ -306,6 +319,10 @@ class ClearFromCache(TestCase):
             asynch_rep_cache.si()
         )
         flow_mock.delay.assert_called_once_with()
+        _msgs.success.assert_called_once_with(
+            request,
+            'Seu pedido de renovação de cache foi recebido e será processado'
+        )
 
 
 @pytest.mark.django_db(transaction=True)

--- a/lupa/tests/test_cache.py
+++ b/lupa/tests/test_cache.py
@@ -19,12 +19,10 @@ from lupa.cache import (
     _repopulate_cache_data_entity,
     _repopulate_cache_data_detail,
     _repopulate_cache_entity,
-    _remove_from_cache
+    _remove_from_cache,
+    repopulate_cache
 )
 from lupa.models import Entidade, DadoEntidade, DadoDetalhe
-from lupa.serializers import (EntidadeSerializer,
-                              DadoEntidadeSerializer,
-                              DadoDetalheSerializer)
 
 
 class Cache(TestCase):
@@ -807,7 +805,6 @@ class RepopulateCache(TestCase):
         _repopulate_cache_data_entity(
             key_prefix='lupa_dado_entidade',
             queryset=queryset,
-            serializer=DadoEntidadeSerializer
         )
 
         execute_sample_calls = [
@@ -1116,7 +1113,6 @@ class RepopulateCache(TestCase):
         _repopulate_cache_data_detail(
             key_prefix='lupa_dado_detalhe',
             queryset=queryset,
-            serializer=DadoDetalheSerializer
         )
 
         execute_sample_calls = [
@@ -1356,7 +1352,6 @@ class RepopulateCache(TestCase):
         _repopulate_cache_entity(
             key_prefix='lupa_entidade',
             queryset=queryset,
-            serializer=EntidadeSerializer
         )
         execute_sample_calls = [
             mock.call(
@@ -1421,6 +1416,7 @@ class RepopulateCache(TestCase):
 
         serializer_mock = mock.MagicMock()
         serializer_mock.side_effect = Exception()
+
         _execute_sample.side_effect = (
             [('33001',)],
         )
@@ -1431,9 +1427,11 @@ class RepopulateCache(TestCase):
         )
 
         queryset = Entidade.objects.all()
-        _repopulate_cache_entity(
+        entities = queryset.distinct('abreviation').order_by('abreviation')
+        repopulate_cache(
             key_prefix='lupa_entidade',
             queryset=queryset,
+            entities=entities,
             serializer=serializer_mock
         )
         expected_msg = 'NOK - %s' % ' - '.join(

--- a/lupa/tests/test_models.py
+++ b/lupa/tests/test_models.py
@@ -361,12 +361,13 @@ class RenewCacheWhenIsCachebleIsChanged(TestCase):
         entidade.is_cacheable = False
         entidade.save()
 
-        expected_queryset = Entidade.objects.filter(pk=entidade.pk)
+        expected_entidade = Entidade.objects.filter(pk=entidade.pk).first()
         asynch_call = _asynch_remove.delay.call_args_list[0][0]
 
         self.assertEqual(asynch_call[0], ENTITY_KEY_PREFIX)
         self.assertEqual(asynch_call[1], ['abreviation'])
-        self.assertEqual(asynch_call[2].first(), expected_queryset.first())
+        self.assertEqual(asynch_call[2].first(), expected_entidade)
+        self.assertFalse(expected_entidade.is_cacheable)
 
     @mock.patch('lupa.models.asynch_repopulate_cache_entity')
     def test_asynch_repopulate_entity_from_cache(self, _asynch_repopulate):
@@ -374,8 +375,9 @@ class RenewCacheWhenIsCachebleIsChanged(TestCase):
         entidade.is_cacheable = True
         entidade.save()
 
-        expected_queryset = Entidade.objects.filter(pk=entidade.pk)
+        expected_entidade = Entidade.objects.filter(pk=entidade.pk).first()
         asynch_call = _asynch_repopulate.delay.call_args_list[0][0]
 
         self.assertEqual(asynch_call[0], ENTITY_KEY_PREFIX)
-        self.assertEqual(asynch_call[1].first(), expected_queryset.first())
+        self.assertEqual(asynch_call[1].first(), expected_entidade)
+        self.assertTrue(expected_entidade.is_cacheable)

--- a/lupa/tests/test_tasks.py
+++ b/lupa/tests/test_tasks.py
@@ -17,25 +17,22 @@ class Task(TestCase):
     def test_call_repopulate_cache_entity(self, _rep_cache):
         asynch_repopulate_cache_entity(
             key_prefix=ENTITY_KEY_PREFIX,
-            queryset=None,
-            serializer=None
+            queryset=None
         )
 
-        _rep_cache.assert_called_once_with(ENTITY_KEY_PREFIX, None, None)
+        _rep_cache.assert_called_once_with(ENTITY_KEY_PREFIX, None)
 
     @mock.patch('lupa.tasks._repopulate_cache_data_entity')
     def test_call_repopulate_cache_data_entity(self, _rep_cache):
         queryset_mock = mock.MagicMock()
         asynch_repopulate_cache_data_entity(
             key_prefix=DATA_ENTITY_KEY_PREFIX,
-            queryset=queryset_mock,
-            serializer=None
+            queryset=queryset_mock
         )
 
         _rep_cache.assert_called_once_with(
             DATA_ENTITY_KEY_PREFIX,
             queryset_mock,
-            None
         )
 
     @mock.patch('lupa.tasks._repopulate_cache_data_detail')
@@ -43,14 +40,12 @@ class Task(TestCase):
         queryset_mock = mock.MagicMock()
         asynch_repopulate_cache_data_detail(
             key_prefix=DATA_DETAIL_KEY_PREFIX,
-            queryset=queryset_mock,
-            serializer=None
+            queryset=queryset_mock
         )
 
         _rep_cache.assert_called_once_with(
             DATA_DETAIL_KEY_PREFIX,
             queryset_mock,
-            None
         )
 
     @mock.patch('lupa.tasks._remove_from_cache')


### PR DESCRIPTION
1 - Cria tasks assíncrona de remoção e renovação do cache quando o campo **is_cacheable** é marcado ou desmarcado, respectivamente.

2 - Retorna mensagem informando que o processo assíncrono de renovação do cache foi iniciado