### PR TITLE
Optimization/outliers query refactor

### DIFF
--- a/dominio/readme.md
+++ b/dominio/readme.md
@@ -81,7 +81,7 @@ Vary: Accept
 ## Outliers
 
 ```
-GET dominio/outliers/<id_orgao>/<yyyy-MM-dd>
+GET dominio/outliers/<id_orgao>
 ```
 
 ```
@@ -91,6 +91,8 @@ Content-Type: application/json
 Vary: Accept
 
 {
+    "cod_orgao": <int:id_orgao>,
+    "acervo_qtd": 10,
     "cod_atribuicao": <int:cod_atribuicao>,
     "minimo": 112,
     "maximo": 290,
@@ -100,7 +102,8 @@ Vary: Accept
     "terceiro_quartil": 182.5,
     "iqr": 42.25,
     "lout": 76.875,
-    "hout": 245.875
+    "hout": 245.875,
+    "dt_inclusao": "2020-03-20 14:28:35"
 }
 ```
 

--- a/dominio/serializers.py
+++ b/dominio/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 
 class OutliersSerializer(serializers.Serializer):
+    cod_orgao = serializers.IntegerField()
     acervo_qtd = serializers.IntegerField(min_value=0)
     cod_atribuicao = serializers.IntegerField()
     minimo = serializers.IntegerField(min_value=0)
@@ -13,6 +14,7 @@ class OutliersSerializer(serializers.Serializer):
     iqr = serializers.FloatField()
     lout = serializers.FloatField()
     hout = serializers.FloatField()
+    dt_inclusao = serializers.DateTimeField()
 
 
 class SaidasSerializer(serializers.Serializer):

--- a/dominio/urls.py
+++ b/dominio/urls.py
@@ -75,8 +75,7 @@ suamesa_patterns = [
 
 stats_patterns = [
     path(
-        'outliers/'
-        '<str:orgao_id>/<str:dt_calculo>',
+        'outliers/<str:orgao_id>',
         OutliersView.as_view(),
         name='outliers'
     ),


### PR DESCRIPTION
Tabela totalmente consolidada no BDA, o que simplifica o serviço no back. A tabela agora salva apenas a distribuição do dia, já que não era necessário o histórico das distribuições (que não é usado, e pode ser recalculado caso necessário), por isso, o endpoint não precisa mais da data.