### PR TITLE
Revisão de queries e correção de determinadas chamadas

### DIFF
--- a/dominio/managers.py
+++ b/dominio/managers.py
@@ -33,8 +33,7 @@ class VistaManager(models.Manager):
         """
         # docu_tpst_dk = 11 : documentos cancelados
         return self.abertas().filter(
-            Q(documento__docu_orgi_orga_dk_responsavel=orgao_id) |
-            Q(documento__docu_orgi_orga_dk_carga=orgao_id),
+            orgao=orgao_id,
             responsavel__cpf=cpf
         ).exclude(documento__docu_tpst_dk=11)
 
@@ -87,9 +86,9 @@ class VistaManager(models.Manager):
         # docu_tpst_dk = 11 : documentos cancelados
         return self.get_queryset().filter(
             Q(data_abertura__gte=date.today() - timedelta(days=30)),
-            Q(documento__docu_orgi_orga_dk_responsavel=orgao_id) |
-            Q(documento__docu_orgi_orga_dk_carga=orgao_id),
+            Q(data_abertura__lte=date.today()),
             Q(documento__docu_cldc_dk__in=[3, 494, 590]),
+            orgao=orgao_id,
             responsavel__cpf=cpf
         ).exclude(documento__docu_tpst_dk=11)
 
@@ -100,7 +99,7 @@ class InvestigacoesManager(models.Manager):
             docu_orgi_orga_dk_responsavel=orgao_id,
             docu_cldc_dk__in=regras,
             docu_fsdc_dk=1
-        )
+        ).exclude(docu_tpst_dk=11)
 
 
 class ProcessosManager(InvestigacoesManager):

--- a/dominio/tutela/tests/test_suamesa.py
+++ b/dominio/tutela/tests/test_suamesa.py
@@ -111,8 +111,13 @@ class SuaMesaViewTest(NoJWTTestCase, NoCacheTestCase, TestCase):
 
         regras_finalizacoes = regras_saidas + regras_arquiv
         manager_mock = mock.MagicMock()
-        manager_mock.count.return_value = 1
+        values_mock = mock.MagicMock()
+        distinct_mock = mock.MagicMock()
+
         _SubAndamento.finalizados.trinta_dias.return_value = manager_mock
+        manager_mock.values.return_value = values_mock
+        values_mock.distinct.return_value = distinct_mock
+        distinct_mock.count.return_value = 1
         orgao_id = '10'
 
         url = reverse('dominio:suamesa-finalizados', args=(orgao_id, ))
@@ -123,7 +128,7 @@ class SuaMesaViewTest(NoJWTTestCase, NoCacheTestCase, TestCase):
         _SubAndamento.finalizados.trinta_dias.assert_called_once_with(
             int(orgao_id), regras_finalizacoes
         )
-        manager_mock.count.assert_called_once_with()
+        distinct_mock.count.assert_called_once_with()
 
     @mock.patch('dominio.tutela.views.Vista')
     def test_sua_mesa_vistas_abertas(self, _Vista):

--- a/dominio/tutela/views.py
+++ b/dominio/tutela/views.py
@@ -334,7 +334,10 @@ class SuaMesaFinalizados(JWTAuthMixin, CacheMixin, APIView):
 
         regras_finalizacoes = regras_saidas + regras_arquiv
         doc_count = SubAndamento.finalizados.trinta_dias(
-            orgao_id, regras_finalizacoes).count()
+            orgao_id, regras_finalizacoes)\
+            .values('andamento__vista__documento__docu_dk')\
+            .distinct()\
+            .count()
 
         return Response(data={"suamesa_finalizados": doc_count})
 


### PR DESCRIPTION
Troca docu_orgi_orga_dk_responsavel para vist_orgi_orga_dk (representado por 'orgao'), nos casos onde essa troca é pertinente. Adiciona docu_tpst_dk != 11 para excluir documentos cancelados. Coloca distinct na query de documentos finalizados.