### PR TITLE
Fix/docu orgi orga to vist orgi orga

### DIFF
--- a/dominio/managers.py
+++ b/dominio/managers.py
@@ -33,8 +33,7 @@ class VistaManager(models.Manager):
         """
         # docu_tpst_dk = 11 : documentos cancelados
         return self.abertas().filter(
-            Q(documento__docu_orgi_orga_dk_responsavel=orgao_id) |
-            Q(documento__docu_orgi_orga_dk_carga=orgao_id),
+            orgao=orgao_id,
             responsavel__cpf=cpf
         ).exclude(documento__docu_tpst_dk=11)
 
@@ -87,9 +86,9 @@ class VistaManager(models.Manager):
         # docu_tpst_dk = 11 : documentos cancelados
         return self.get_queryset().filter(
             Q(data_abertura__gte=date.today() - timedelta(days=30)),
-            Q(documento__docu_orgi_orga_dk_responsavel=orgao_id) |
-            Q(documento__docu_orgi_orga_dk_carga=orgao_id),
+            Q(data_abertura__lte=date.today()),
             Q(documento__docu_cldc_dk__in=[3, 494, 590]),
+            orgao=orgao_id,
             responsavel__cpf=cpf
         ).exclude(documento__docu_tpst_dk=11)
 
@@ -100,7 +99,7 @@ class InvestigacoesManager(models.Manager):
             docu_orgi_orga_dk_responsavel=orgao_id,
             docu_cldc_dk__in=regras,
             docu_fsdc_dk=1
-        )
+        ).exclude(docu_tpst_dk=11)
 
 
 class ProcessosManager(InvestigacoesManager):

--- a/dominio/managers.py
+++ b/dominio/managers.py
@@ -31,11 +31,10 @@ class VistaManager(models.Manager):
         Returns:
             List[Tuple] -- Lista com o resultado da query.
         """
-        # docu_tpst_dk = 11 : documentos cancelados
         return self.abertas().filter(
             orgao=orgao_id,
             responsavel__cpf=cpf
-        ).exclude(documento__docu_tpst_dk=11)
+        )
 
     def abertas_por_data(self, orgao_id, cpf):
         """
@@ -83,14 +82,13 @@ class VistaManager(models.Manager):
 
     def aberturas_30_dias_PIP(self, orgao_id, cpf):
         # cldc_dk 590 = PIC, 3 e 494 = Inquerito Policial
-        # docu_tpst_dk = 11 : documentos cancelados
         return self.get_queryset().filter(
             Q(data_abertura__gte=date.today() - timedelta(days=30)),
             Q(data_abertura__lte=date.today()),
             Q(documento__docu_cldc_dk__in=[3, 494, 590]),
             orgao=orgao_id,
             responsavel__cpf=cpf
-        ).exclude(documento__docu_tpst_dk=11)
+        )
 
 
 class InvestigacoesManager(models.Manager):
@@ -122,8 +120,9 @@ class FinalizadosManager(models.Manager):
     def no_orgao(self, org_id, regras_saidas):
         return self.get_queryset().filter(
             andamento__vista__documento__docu_orgi_orga_dk_responsavel=org_id,
-            stao_tppr_dk__in=regras_saidas
-        )
+            stao_tppr_dk__in=regras_saidas,
+            andamento__pcao_dt_cancelamento__isnull=True
+        ).exclude(andamento__vista__documento__docu_tpst_dk=11)
 
     def trinta_dias(self, orgao_id, regras_saidas):
         finalizados = self.no_orgao(orgao_id, regras_saidas)

--- a/dominio/managers.py
+++ b/dominio/managers.py
@@ -118,6 +118,8 @@ class ProcessosManager(InvestigacoesManager):
 
 class FinalizadosManager(models.Manager):
     def no_orgao(self, org_id, regras_saidas):
+        # docu_tpst_dk = 11 : documentos cancelados (desconsiderados)
+        # pcao_dt_cancelamento = null : andamentos valido
         return self.get_queryset().filter(
             andamento__vista__documento__docu_orgi_orga_dk_responsavel=org_id,
             stao_tppr_dk__in=regras_saidas,

--- a/dominio/models.py
+++ b/dominio/models.py
@@ -153,6 +153,10 @@ class Andamento(models.Model):
     pcao_dt_andamento = models.DateField(
         db_column="PCAO_DT_ANDAMENTO"
     )
+    pcao_dt_cancelamento = models.DateField(
+        null=True,
+        db_column='PCAO_DT_CANCELAMENTO'
+    )
 
     vista = models.ForeignKey(
         "Vista",

--- a/dominio/tutela/tests/test_suamesa.py
+++ b/dominio/tutela/tests/test_suamesa.py
@@ -111,8 +111,13 @@ class SuaMesaViewTest(NoJWTTestCase, NoCacheTestCase, TestCase):
 
         regras_finalizacoes = regras_saidas + regras_arquiv
         manager_mock = mock.MagicMock()
-        manager_mock.count.return_value = 1
+        values_mock = mock.MagicMock()
+        distinct_mock = mock.MagicMock()
+
         _SubAndamento.finalizados.trinta_dias.return_value = manager_mock
+        manager_mock.values.return_value = values_mock
+        values_mock.distinct.return_value = distinct_mock
+        distinct_mock.count.return_value = 1
         orgao_id = '10'
 
         url = reverse('dominio:suamesa-finalizados', args=(orgao_id, ))
@@ -123,7 +128,7 @@ class SuaMesaViewTest(NoJWTTestCase, NoCacheTestCase, TestCase):
         _SubAndamento.finalizados.trinta_dias.assert_called_once_with(
             int(orgao_id), regras_finalizacoes
         )
-        manager_mock.count.assert_called_once_with()
+        distinct_mock.count.assert_called_once_with()
 
     @mock.patch('dominio.tutela.views.Vista')
     def test_sua_mesa_vistas_abertas(self, _Vista):

--- a/dominio/tutela/views.py
+++ b/dominio/tutela/views.py
@@ -518,6 +518,8 @@ class DesarquivamentosView(JWTAuthMixin, CacheMixin, APIView):
                                           7803, 6003, 7802, 7801)
                                           AND d.docu_cldc_dk = 392
                 AND d.DOCU_ORGI_ORGA_DK_RESPONSAVEL = %s
+                AND d.DOCU_TPST_DK != 11
+                AND a.pcao_dt_cancelamento IS NULL
                 GROUP BY docu_nr_mp, a.pcao_dt_andamento)
                 SELECT docu_nr_mp, COUNT(docu_nr_mp)
                 FROM AGRUPADOS GROUP BY docu_nr_mp

--- a/dominio/tutela/views.py
+++ b/dominio/tutela/views.py
@@ -334,7 +334,10 @@ class SuaMesaFinalizados(JWTAuthMixin, CacheMixin, APIView):
 
         regras_finalizacoes = regras_saidas + regras_arquiv
         doc_count = SubAndamento.finalizados.trinta_dias(
-            orgao_id, regras_finalizacoes).count()
+            orgao_id, regras_finalizacoes)\
+            .values('andamento__vista__documento__docu_dk')\
+            .distinct()\
+            .count()
 
         return Response(data={"suamesa_finalizados": doc_count})
 


### PR DESCRIPTION
Queries Oracle relativas a Vistas consideram documentos cancelados (pode haver vistas para documentos cancelados). Além disso, devem olhar para o vist_orgi_orga_dk e não para o docu_orgi_orga_dk_responsavel.
Investigações Em Curso desconsideram documentos cancelados.
Finalizados desconsideram documentos cancelados e também andamentos cancelados. Os dois devem ser válidos.