### PR TITLE
Remove zeros na frente do número do RG

### DIFF
--- a/proxies/detran/tests/test_views.py
+++ b/proxies/detran/tests/test_views.py
@@ -23,12 +23,14 @@ class TestDetranProxyView(TestCase):
         controller_mock.get_data.return_value = {"data": 1}
         _DataController.return_value = controller_mock
 
-        rg = "12345"
+        # View must remove padding zero
+        rg = "012345"
         url = reverse("proxies:foto-detran", kwargs={"rg": rg})
         resp = self.client.get(url)
+        expected_used_rg = str(int(rg))
 
         _DataController.assert_called_once_with(
-            rg=rg,
+            rg=expected_used_rg,
             data_dao=_Impala.return_value,
             photo_dao=_HBase.return_value,
         )

--- a/proxies/detran/views.py
+++ b/proxies/detran/views.py
@@ -30,7 +30,8 @@ class FotoDetranView(APIView):
 
     @token_required(name="proxy-token")
     def get(self, request, *args, **kwargs):
-        rg = kwargs.get("rg")
+        # Remove padding zeros
+        rg = str(int(kwargs.get("rg", "1")))
 
         data_controller = self.start_controller(rg)
         try:


### PR DESCRIPTION
Ignora os zeros que estão na frente do RG logo no início da `view.py`:

Exemplo: se a requisição for feita com RG `0123456`, o valor `123456` será procurado no BD.