### PR TITLE
Enhancement/orgao selecionado

### DIFF
--- a/dominio/login/dao.py
+++ b/dominio/login/dao.py
@@ -8,7 +8,15 @@ from lupa.db_connectors import oracle_access
 class ListaOrgaosDAO(GenericDAO):
     QUERIES_DIR = settings.BASE_DIR.child("dominio", "login", "queries")
     query_file = "lista_orgaos.sql"
-    columns = ["cdorgao", "nm_org"]
+    columns = [
+        "cdorgao",
+        "nm_org",
+        "matricula",
+        "cpf",
+        "nome",
+        "sexo",
+        "pess_dk",
+    ]
     serializer = serializers.ListaOrgaosSerializer
 
     @classmethod
@@ -16,15 +24,9 @@ class ListaOrgaosDAO(GenericDAO):
         return oracle_access(cls.query(), kwargs)
 
 
-class ListaOrgaosPessoalDAO(GenericDAO):
-    QUERIES_DIR = settings.BASE_DIR.child("dominio", "login", "queries")
+class ListaOrgaosPessoalDAO(ListaOrgaosDAO):
     query_file = "lista_orgaos_pessoal.sql"
-    columns = ["cdorgao", "nm_org"]
     serializer = serializers.ListaOrgaosSerializer
-
-    @classmethod
-    def execute(cls, **kwargs):
-        return oracle_access(cls.query(), kwargs)
 
 
 class ListaTodosOrgaosDAO(GenericDAO):
@@ -39,7 +41,7 @@ class ListaTodosOrgaosDAO(GenericDAO):
         "sexo",
         "pess_dk",
     ]
-    serializer = serializers.ListaTodosOrgaosSerializer
+    serializer = serializers.ListaOrgaosSerializer
 
     @classmethod
     def execute(cls, **kwargs):

--- a/dominio/login/queries/lista_orgaos.sql
+++ b/dominio/login/queries/lista_orgaos.sql
@@ -1,6 +1,11 @@
 select
 	h.cdorgao as cdorgao,
-	o.ORGI_NM_ORGAO as nm_org
+	o.ORGI_NM_ORGAO as nm_org,
+    rhf.cdmatricula as matricula,
+    rhf.cpf,
+    rhf.nmfuncionario as nome,
+    rhf.SEXO as sexo,
+    rhf.PESF_PESS_DK as pess_dk
 from hist_func h
 	join MPRJ_VW_FUNCIONARIO f on f.cdmatricula = h.cdmatricula
 	join RH_FUNCIONARIO rhf on rhf.CDMATRICULA = h.cdmatricula
@@ -16,4 +21,4 @@ where rhf.E_MAIL1 = LOWER(TRIM(:login))                           -- Matrícula 
 				and lower(h.obs) not like '%especificamente%'
 			))) or (f.CDTIPFUNC <> 1))                            -- Ou que não seja MP_ATIVO
 
-GROUP BY h.cdorgao, o.ORGI_NM_ORGAO
+GROUP BY h.cdorgao, o.ORGI_NM_ORGAO, rhf.cdmatricula, rhf.cpf, rhf.nmfuncionario, rhf.SEXO, rhf.PESF_PESS_DK

--- a/dominio/login/queries/lista_orgaos_pessoal.sql
+++ b/dominio/login/queries/lista_orgaos_pessoal.sql
@@ -1,6 +1,11 @@
 SELECT
 	o.ORGI_CDORGAO AS cdorgao,
-	o.ORGI_NM_ORGAO AS nm_org
+	o.ORGI_NM_ORGAO AS nm_org,
+    rhf.cdmatricula as matricula,
+    rhf.cpf,
+    rhf.nmfuncionario as nome,
+    rhf.SEXO as sexo,
+    rhf.PESF_PESS_DK as pess_dk
 FROM
 	RH_MOVIMENTACAO_FUNCIONARIO mf
     JOIN RH_FUNCIONARIO rhf ON rhf.CDMATRICULA = mf.MOFU_CDMATRICULA
@@ -10,4 +15,4 @@ WHERE
 	rhf.E_MAIL1 = LOWER(TRIM(:login))
 	AND (MOFU_DT_FIM is null or MOFU_DT_FIM > sysdate)
 
-GROUP BY o.ORGI_CDORGAO, o.ORGI_NM_ORGAO
+GROUP BY o.ORGI_CDORGAO, o.ORGI_NM_ORGAO, rhf.cdmatricula, rhf.cpf, rhf.nmfuncionario, rhf.SEXO, rhf.PESF_PESS_DK

--- a/dominio/login/serializers.py
+++ b/dominio/login/serializers.py
@@ -4,11 +4,6 @@ from rest_framework import serializers
 class ListaOrgaosSerializer(serializers.Serializer):
     cdorgao = serializers.CharField()
     nm_org = serializers.CharField()
-
-
-class ListaTodosOrgaosSerializer(serializers.Serializer):
-    cdorgao = serializers.CharField()
-    nm_org = serializers.CharField()
     matricula = serializers.CharField()
     cpf = serializers.CharField()
     nome = serializers.CharField()

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -82,6 +82,7 @@ class PermissaoUsuario:
 
 
 class PermissoesUsuarioRegular(PermissaoUsuario):
+    type = "regular"
     DaoWrapper = namedtuple("PermissaoDao", ["handler", "kwargs"])
     permissoes_dao = [
         DaoWrapper(dao.ListaOrgaosDAO, {"accept_empty": False}),
@@ -90,6 +91,7 @@ class PermissoesUsuarioRegular(PermissaoUsuario):
 
 
 class PermissoesUsuarioAdmin(PermissaoUsuario):
+    type = "admin"
     DaoWrapper = namedtuple("PermissaoDao", ["handler", "kwargs"])
     permissoes_dao = [
         DaoWrapper(dao.ListaTodosOrgaosDAO, {"accept_empty": False}),
@@ -137,6 +139,7 @@ def build_login_response(permissoes):
     response["username"] = usuario.username
     response["first_login"] = created
     response["first_login_today"] = created or usuario.get_first_login_today()
+    response["tipo_permissao"] = permissoes.type
 
     # Informações do usuário
     response["sexo"] = permissoes.dados_usuario["sexo"]

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -100,13 +100,12 @@ class PermissoesUsuarioAdmin(PermissaoUsuario):
 
     @property
     def orgaos_validos(self):
-        orgaos = list(
-            {
-                orgao["cdorgao"]: orgao
-                for orgao in self.orgaos_lotados + self.todos_orgaos
-            }.values()
-        )
-        return self._filtra_orgaos_invalidos(orgaos)
+        return self._filtra_orgaos_invalidos(self.todos_orgaos)
+
+    @property
+    def orgao_selecionado(self):
+        lotados_validos = self._filtra_orgaos_invalidos(self.orgaos_lotados)
+        return lotados_validos[0] if lotados_validos else self.orgaos_validos[0]
 
 
 def permissoes_router(info):

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -105,7 +105,9 @@ class PermissoesUsuarioAdmin(PermissaoUsuario):
     @property
     def orgao_selecionado(self):
         lotados_validos = self._filtra_orgaos_invalidos(self.orgaos_lotados)
-        return lotados_validos[0] if lotados_validos else self.orgaos_validos[0]
+        return (
+            lotados_validos[0] if lotados_validos else self.orgaos_validos[0]
+        )
 
 
 def permissoes_router(info):

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -514,47 +514,14 @@ class TesPermissoesUsuarioAdmin(TestCase):
 
     def test_retorna_todos_orgaos_validos(self):
         self.mock_oracle_access.side_effect = [
-            self.oracle_return_lista_orgaos_lotados,
-            (),
             self.oracle_return_lista_todos_orgaos,
         ]
         orgaos = self.permissoes.orgaos_validos
-        expected = [
-            {
-                "cpf": "cpf 1",
-                "pess_dk": "pess_dk 1",
-                "nome": "nome 1",
-                "matricula": "matricula 1",
-                "sexo": "X",
-                "cdorgao": "cdorgao 1",
-                "nm_org": "PROMOTORIA INVESTIGAÇÃO PENAL",
-                "tipo": 2,
-            },
-            {
-                "cpf": "cpf 3",
-                "pess_dk": "pess_dk 3",
-                "nome": "nome 3",
-                "matricula": "matricula 3",
-                "sexo": "X",
-                "cdorgao": "cdorgao 3",
-                "nm_org": "PROMOTORIA TUTELA COLETIVA",
-                "tipo": 1,
-            },
-            {
-                "cpf": "cpf 5",
-                "pess_dk": "pess_dk 5",
-                "nome": "nome 5",
-                "matricula": "matricula 5",
-                "sexo": "X",
-                "cdorgao": "cdorgao 5",
-                "nm_org": "PROMOTORIA TUTELA COLETIVA",
-                "tipo": 1,
-            },
-        ]
+        self.expected.pop(1)
 
-        self.assertCountEqual(orgaos, expected)
+        self.assertCountEqual(orgaos, self.expected)
 
-    def test_orgao_selecionado_permissao_admin(self):
+    def test_orgao_selecionado_permissao_admin_seleciona_lotado(self):
         "Deve tentar selecionar primeiro um orgao lotado valido"
         self.mock_oracle_access.side_effect = [
             self.oracle_return_lista_orgaos_lotados,
@@ -575,3 +542,23 @@ class TesPermissoesUsuarioAdmin(TestCase):
         orgao_selecionado = self.permissoes.orgao_selecionado
 
         self.assertEqual(orgao_selecionado, expected)
+
+    def test_orgao_selecionado_permissao_admin_seleciona_primeiro_lista(self):
+        "Deve tentar selecionar primeiro um orgao lotado valido"
+        self.mock_oracle_access.side_effect = [
+            ((
+                "cdorgao 2",
+                "PROMOTORIA DIFERENTE",
+                "matricula 2",
+                "cpf 2",
+                "nome 2",
+                "X",
+                "pess_dk 2",
+            ),),
+            (),
+            self.oracle_return_lista_todos_orgaos,
+        ]
+
+        orgao_selecionado = self.permissoes.orgao_selecionado
+
+        self.assertEqual(orgao_selecionado, self.expected[0])

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -29,11 +29,35 @@ class TestBuildLoginResponse(TestCase):
         self.mock_oracle_access.side_effect = [
             self.oracle_return_dados_usuario,
             (
-                ("098765", "PROMOTORIA INVESTIGAÇÃO PENAL"),
-                ("1234", "PROMOTORIA DIFERENTE"),
+                (
+                    "098765",
+                    "PROMOTORIA INVESTIGAÇÃO PENAL",
+                    "MATRICULA 1",
+                    "CPF 1",
+                    "NOME 1",
+                    "X",
+                    "PESS_DK 1",
+                ),
+                (
+                    "1234",
+                    "PROMOTORIA DIFERENTE",
+                    "MATRICULA 2",
+                    "CPF 2",
+                    "NOME 2",
+                    "X",
+                    "PESS_DK 2",
+                ),
             ),
             (
-                ("1234", "PROMOTORIA TUTELA COLETIVA"),
+                (
+                    "1234",
+                    "PROMOTORIA TUTELA COLETIVA",
+                    "MATRICULA 3",
+                    "CPF 3",
+                    "NOME 3",
+                    "X",
+                    "PESS_DK 3",
+                ),
             ),  # result set do lista orgao pessoal
         ]
         self.expected_response = {
@@ -51,20 +75,20 @@ class TestBuildLoginResponse(TestCase):
             "tipo_permissao": "regular",
             "orgaos_validos": [
                 {
-                    "cpf": "123456789",
-                    "matricula": "12345",
-                    "pess_dk": "4567",
-                    "nome": "NOME FUNCIONARIO",
+                    "cpf": "CPF 1",
+                    "matricula": "MATRICULA 1",
+                    "pess_dk": "PESS_DK 1",
+                    "nome": "NOME 1",
                     "sexo": "X",
                     "nm_org": "PROMOTORIA INVESTIGAÇÃO PENAL",
                     "tipo": 2,
                     "cdorgao": "098765",
                 },
                 {
-                    "cpf": "123456789",
-                    "matricula": "12345",
-                    "pess_dk": "4567",
-                    "nome": "NOME FUNCIONARIO",
+                    "cpf": "CPF 3",
+                    "matricula": "MATRICULA 3",
+                    "pess_dk": "PESS_DK 3",
+                    "nome": "NOME 3",
                     "sexo": "X",
                     "nm_org": "PROMOTORIA TUTELA COLETIVA",
                     "tipo": 1,
@@ -149,11 +173,36 @@ class TestPermissoesUsuarioRegular(TestCase):
             ("12345", "123456789", "NOME FUNCIONARIO", "X", "4567"),
         )
         self.oracle_return_lista_orgao = (
-            ("098765", "PROMOTORIA INVESTIGAÇÃO PENAL"),
-            ("1234", "PROMOTORIA DIFERENTE"),
+            (
+                "098765",
+                "PROMOTORIA INVESTIGAÇÃO PENAL",
+                "MATRICULA 1",
+                "CPF 1",
+                "NOME 1",
+                "X",
+                "PESS_DK 1",
+
+            ),
+            (
+                "1234",
+                "PROMOTORIA DIFERENTE",
+                "MATRICULA 2",
+                "CPF 2",
+                "NOME 2",
+                "X",
+                "PESS_DK 2",
+            ),
         )
         self.oracle_return_lista_orgao_pessoal = (
-            ("9999", "PROMOTORIA TUTELA COLETIVA"),
+            (
+                "9999",
+                "PROMOTORIA TUTELA COLETIVA",
+                "MATRICULA 3",
+                "CPF 3",
+                "NOME 3",
+                "X",
+                "PESS_DK 3",
+            ),
         )
         self.mock_oracle_access.side_effect = [
             self.oracle_return_lista_orgao,
@@ -162,30 +211,30 @@ class TestPermissoesUsuarioRegular(TestCase):
         ]
         self.expected = [
             {
-                "cpf": "123456789",
-                "pess_dk": "4567",
-                "nome": "NOME FUNCIONARIO",
-                "matricula": "12345",
+                "cpf": "CPF 1",
+                "pess_dk": "PESS_DK 1",
+                "nome": "NOME 1",
+                "matricula": "MATRICULA 1",
                 "sexo": "X",
                 "cdorgao": "098765",
                 "nm_org": "PROMOTORIA INVESTIGAÇÃO PENAL",
                 "tipo": 2,
             },
             {
-                "cpf": "123456789",
-                "pess_dk": "4567",
-                "nome": "NOME FUNCIONARIO",
-                "matricula": "12345",
+                "cpf": "CPF 2",
+                "pess_dk": "PESS_DK 2",
+                "nome": "NOME 2",
+                "matricula": "MATRICULA 2",
                 "sexo": "X",
                 "cdorgao": "1234",
                 "nm_org": "PROMOTORIA DIFERENTE",
                 "tipo": 0,
             },
             {
-                "cpf": "123456789",
-                "pess_dk": "4567",
-                "nome": "NOME FUNCIONARIO",
-                "matricula": "12345",
+                "cpf": "CPF 3",
+                "pess_dk": "PESS_DK 3",
+                "nome": "NOME 3",
+                "matricula": "MATRICULA 3",
                 "sexo": "X",
                 "cdorgao": "9999",
                 "nm_org": "PROMOTORIA TUTELA COLETIVA",
@@ -398,6 +447,26 @@ class TesPermissoesUsuarioAdmin(TestCase):
                 "pess_dk 3",
             ),
         )
+        self.oracle_return_lista_orgaos_lotados = (
+            (
+                "cdorgao 2",
+                "PROMOTORIA DIFERENTE",
+                "matricula 2",
+                "cpf 2",
+                "nome 2",
+                "X",
+                "pess_dk 2",
+            ),
+            (
+                "cdorgao 5",
+                "PROMOTORIA TUTELA COLETIVA",
+                "matricula 5",
+                "cpf 5",
+                "nome 5",
+                "X",
+                "pess_dk 5",
+            ),
+        )
         self.mock_oracle_access.side_effect = [
             self.oracle_return_lista_todos_orgaos,
             self.oracle_return_dados_usuario,
@@ -438,7 +507,71 @@ class TesPermissoesUsuarioAdmin(TestCase):
             username=self.username
         )
 
-    def test_retorna_todos_orgaos_lotados(self):
-        orgaos = self.permissoes.orgaos_lotados
+    def test_retorna_todos_orgaos(self):
+        orgaos = self.permissoes.todos_orgaos
 
         self.assertEqual(orgaos, self.expected)
+
+    def test_retorna_todos_orgaos_validos(self):
+        self.mock_oracle_access.side_effect = [
+            self.oracle_return_lista_orgaos_lotados,
+            (),
+            self.oracle_return_lista_todos_orgaos,
+        ]
+        orgaos = self.permissoes.orgaos_validos
+        expected = [
+            {
+                "cpf": "cpf 1",
+                "pess_dk": "pess_dk 1",
+                "nome": "nome 1",
+                "matricula": "matricula 1",
+                "sexo": "X",
+                "cdorgao": "cdorgao 1",
+                "nm_org": "PROMOTORIA INVESTIGAÇÃO PENAL",
+                "tipo": 2,
+            },
+            {
+                "cpf": "cpf 3",
+                "pess_dk": "pess_dk 3",
+                "nome": "nome 3",
+                "matricula": "matricula 3",
+                "sexo": "X",
+                "cdorgao": "cdorgao 3",
+                "nm_org": "PROMOTORIA TUTELA COLETIVA",
+                "tipo": 1,
+            },
+            {
+                "cpf": "cpf 5",
+                "pess_dk": "pess_dk 5",
+                "nome": "nome 5",
+                "matricula": "matricula 5",
+                "sexo": "X",
+                "cdorgao": "cdorgao 5",
+                "nm_org": "PROMOTORIA TUTELA COLETIVA",
+                "tipo": 1,
+            },
+        ]
+
+        self.assertCountEqual(orgaos, expected)
+
+    def test_orgao_selecionado_permissao_admin(self):
+        "Deve tentar selecionar primeiro um orgao lotado valido"
+        self.mock_oracle_access.side_effect = [
+            self.oracle_return_lista_orgaos_lotados,
+            (),
+            self.oracle_return_lista_todos_orgaos,
+        ]
+        expected = {
+                "cpf": "cpf 5",
+                "pess_dk": "pess_dk 5",
+                "nome": "nome 5",
+                "matricula": "matricula 5",
+                "sexo": "X",
+                "cdorgao": "cdorgao 5",
+                "nm_org": "PROMOTORIA TUTELA COLETIVA",
+                "tipo": 1,
+            }
+
+        orgao_selecionado = self.permissoes.orgao_selecionado
+
+        self.assertEqual(orgao_selecionado, expected)

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -48,6 +48,7 @@ class TestBuildLoginResponse(TestCase):
             "first_login_today": True,
             "sexo": "X",
             "token": "auth-token",
+            "tipo_permissao": "regular",
             "orgaos_validos": [
                 {
                     "cpf": "123456789",

--- a/login/jwtlogin.py
+++ b/login/jwtlogin.py
@@ -13,12 +13,13 @@ def get_jwt_from_get(request):
 
 
 def tipo_orgao(nome_orgao):
+    tutela_deny_list = ["idoso", "infância", "centro de apoio operacional"]
     nome_orgao = nome_orgao.lower()
     if "investigação penal" in nome_orgao:
         orgao = 2
     elif (
         "tutela" in nome_orgao
-        and not ("idoso" in nome_orgao or "infância" in nome_orgao)
+        and not any(deny in nome_orgao for deny in tutela_deny_list)
     ):
         orgao = 1
     else:

--- a/login/tests/test_jwtlogin.py
+++ b/login/tests/test_jwtlogin.py
@@ -65,6 +65,15 @@ class TestJWTLogin(TestCase):
         self.assertEqual(tipo_orgao_3, 0)
         self.assertEqual(tipo_orgao_4, 0)
 
+    def test_tipo_orgao_CAO(self):
+        nome_orgao_cao = (
+            "CENTRO DE APOIO OPERACIONAL DAS PROMOTORIAS"
+            " DE JUSTIÇA DE TUTELA COLETIVA"
+        )
+        tipo_do_orgao = tipo_orgao(nome_orgao_cao)
+
+        self.assertEqual(tipo_do_orgao, 0)
+
     @mock.patch('login.jwtlogin.jwt.decode', return_value="payload")
     @mock.patch('login.jwtlogin.get_jwt_from_get', return_value="TOKEN")
     def test_unpack_jwt(self, _get_jwt, _decode):


### PR DESCRIPTION
Adicionei um campo à resposta do login:

 `permissao_tipo`: diz se o usuário foi logado como admin ou regular.


Agora, caso o usuário tenha Role de Admin, o backend verifica se algum órgão que o usuário esteja lotado é válido (do ponto de vista do Parquet Digital), caso positivo esse órgão é selecionado, caso contrário, será o primeiro da lista de TODOS os órgãos válidos para o Parquet Digital
