### PR TITLE
Feature/perfil investigado fase documento

### DIFF
--- a/dominio/pip/dao.py
+++ b/dominio/pip/dao.py
@@ -261,6 +261,7 @@ class PIPPrincipaisInvestigadosListaDAO(GenericPIPDAO):
         "nm_orgao",
         "etiqueta",
         "assuntos",
+        "fase_documento"
     ]
     table_namespaces = {"schema": settings.TABLE_NAMESPACE}
     serializer = PIPPrincipaisInvestigadosListaSerializer
@@ -269,8 +270,8 @@ class PIPPrincipaisInvestigadosListaDAO(GenericPIPDAO):
     def serialize(cls, result_set):
         # Assuntos vem separados por ' --- ' no banco
         result_set = [
-            row[:-1] + tuple([row[-1].split(' --- ')])
-            if isinstance(row[-1], str)
+            row[:-2] + tuple([row[-2].split(' --- ')]) + row[-1:]
+            if isinstance(row[-2], str)
             else row
             for row in result_set
         ]

--- a/dominio/pip/dao.py
+++ b/dominio/pip/dao.py
@@ -254,6 +254,8 @@ class PIPPrincipaisInvestigadosListaDAO(GenericPIPDAO):
     query_file = "pip_principais_investigados_lista.sql"
     columns = [
         "representante_dk",
+        "nm_investigado",
+        "tipo_personagem",
         "orgao_id",
         "documento_nr_mp",
         "documento_dt_cadastro",

--- a/dominio/pip/queries/pip_principais_investigados_lista.sql
+++ b/dominio/pip/queries/pip_principais_investigados_lista.sql
@@ -1,3 +1,14 @@
-SELECT *
+SELECT 
+    representante_dk,
+    pess_nm_pessoa,
+    tppe_descricao,
+    pip_codigo,
+    docu_nr_mp,
+    docu_dt_cadastro,
+    cldc_ds_classe,
+    orgi_nm_orgao,
+    docu_tx_etiqueta,
+    assuntos,
+    fsdc_ds_fase
 FROM {schema}.tb_pip_investigados_procedimentos
 WHERE representante_dk = :dk

--- a/dominio/pip/serializers.py
+++ b/dominio/pip/serializers.py
@@ -32,6 +32,7 @@ class PIPPrincipaisInvestigadosListaSerializer(serializers.Serializer):
     nm_orgao = serializers.CharField()
     etiqueta = serializers.CharField()
     assuntos = serializers.ListField(serializers.CharField())
+    fase_documento = serializers.CharField()
 
 
 class PIPIndicadoresSucessoParser(serializers.Serializer):

--- a/dominio/pip/serializers.py
+++ b/dominio/pip/serializers.py
@@ -25,6 +25,8 @@ class PIPPrincipaisInvestigadosSerializer(serializers.Serializer):
 
 class PIPPrincipaisInvestigadosListaSerializer(serializers.Serializer):
     representante_dk = serializers.IntegerField()
+    nm_investigado = serializers.CharField()
+    tipo_personagem = serializers.CharField()
     orgao_id = serializers.IntegerField()
     documento_nr_mp = serializers.CharField()
     documento_dt_cadastro = serializers.DateTimeField()

--- a/dominio/pip/tests/test_dao.py
+++ b/dominio/pip/tests/test_dao.py
@@ -391,24 +391,30 @@ class TestPIPPrincipaisInvestigadosListaDAO:
         result_set = [
             (
                 16,
+                "Nome",
+                "Tipo",
                 29933850,
                 "123456",
                 datetime(2020, 4, 22, 13, 36, 6, 668000),
                 "Classe",
                 "5ª PROMOTORIA DE JUSTIÇA",
                 "Etiqueta",
-                "Assunto 1 --- Assunto 2"
+                "Assunto 1 --- Assunto 2",
+                "FaseDoc"
             ),
         ]
         ser_data = PIPPrincipaisInvestigadosListaDAO.serialize(result_set)
         expected_data = [{
             "representante_dk": 16,
+            "nm_investigado": "Nome",
+            "tipo_personagem": "Tipo",
             "orgao_id": 29933850,
             "documento_nr_mp": "123456",
             "documento_dt_cadastro": '2020-04-22T13:36:06.668000Z',
             "documento_classe": "Classe",
             "nm_orgao": "5ª Promotoria de Justiça",
             "etiqueta": "Etiqueta",
-            "assuntos": ["Assunto 1", "Assunto 2"]
+            "assuntos": ["Assunto 1", "Assunto 2"],
+            "fase_documento": "FaseDoc"
         }]
         assert ser_data == expected_data

--- a/dominio/pip/views.py
+++ b/dominio/pip/views.py
@@ -112,7 +112,7 @@ class PIPRadarPerformanceView(JWTAuthMixin, CacheMixin, APIView):
 
 
 class PIPPrincipaisInvestigadosView(
-        JWTAuthMixin, CacheMixin, PaginatorMixin, APIView):
+        JWTAuthMixin, PaginatorMixin, APIView):
     cache_config = "PIP_PRINCIPAIS_INVESTIGADOS_CACHE_TIMEOUT"
     PRINCIPAIS_INVESTIGADOS_SIZE = 20
 


### PR DESCRIPTION
Adiciona colunas novas no Principais Investigados Lista (Perfil do investigado).

Além disso, tira o cache da View do Principais Investigados e o transfere a mais baixo nível para o DAO correspondente. O cache agora é chamado separadamente para as flags e para os dados vindos do Impala. Quando uma nova flag é salva, o cache das flags é resetado para aquele órgão/CPF.

Isso conserta um problema em que um POST (para modificar alguma flag de pin ou remove) seguido de um GET muito rapidamente fazia com que as flags viessem desatualizadas (já que a View ainda estava cacheada). Utilizando o cache separadamente, este problema é consertado.
Além disso, agora os dados vindos do Impala (que são referentes ao mesmo órgão) podem ser aproveitados entre CPFs. Isso quer dizer que no caso de dois CPFs atrelados ao mesmo órgão, A e B, se A fizer o request, e B o fizer logo depois, B aproveitará os dados cacheados de A (com exceção das flags do HBase, que são associadas a cada CPF).