### PR TITLE
Fix/login dps

### DIFF
--- a/dominio/login/dao.py
+++ b/dominio/login/dao.py
@@ -66,3 +66,19 @@ class DadosUsuarioDAO(SingleDataObjectDAO):
     @classmethod
     def execute(cls, **kwargs):
         return oracle_access(cls.query(), kwargs)
+
+
+class DPsPIPDAO(SingleDataObjectDAO):
+    QUERIES_DIR = settings.BASE_DIR.child("dominio", "login", "queries")
+    query_file = "get_dps_orgao.sql"
+    columns = ["id_orgao", "dps"]
+    serializer = serializers.DPsPIPSerializer
+    table_namespaces = {"schema": settings.TABLE_NAMESPACE}
+
+
+class ListaDPsPIPsDAO(GenericDAO):
+    QUERIES_DIR = settings.BASE_DIR.child("dominio", "login", "queries")
+    query_file = "get_lista_dps.sql"
+    columns = ["id_orgao", "dps"]
+    serializer = serializers.DPsPIPSerializer
+    table_namespaces = {"schema": settings.TABLE_NAMESPACE}

--- a/dominio/login/integra.py
+++ b/dominio/login/integra.py
@@ -3,6 +3,7 @@ import jwt
 from django.conf import settings
 
 from login.jwtlogin import get_jwt_from_post, tipo_orgao
+from dominio.login.dao import DPsPIPDAO
 
 
 login_logger = logging.getLogger(__name__)
@@ -26,6 +27,8 @@ def authenticate_integra(request):
     nome_orgao = payload['scaUser']['nomeOrgaoUsuario']
     matricula = payload["scaUser"]["matricula"]
 
+    dps = DPsPIPDAO.get(accept_empty=True, orgao=int(orgao)).get('dps', '')
+
     payload = {
         'username': user_name,
         'cpf': cpf,
@@ -34,6 +37,7 @@ def authenticate_integra(request):
         'nome': nome_usuario,
         'tipo_orgao': tipo_orgao(nome_orgao),
         'matricula': matricula,
+        'dps': dps
     }
 
     token = jwt.encode(

--- a/dominio/login/queries/get_dps_orgao.sql
+++ b/dominio/login/queries/get_dps_orgao.sql
@@ -1,0 +1,4 @@
+SELECT pip_codigo, group_concat(cast(cisp_codigo as string), ',')
+FROM {schema}.tb_pip_cisp
+WHERE pip_codigo = :orgao
+GROUP BY pip_codigo

--- a/dominio/login/queries/get_lista_dps.sql
+++ b/dominio/login/queries/get_lista_dps.sql
@@ -1,0 +1,3 @@
+SELECT pip_codigo, group_concat(cast(cisp_codigo as string), ',')
+FROM {schema}.tb_pip_cisp
+GROUP BY pip_codigo

--- a/dominio/login/serializers.py
+++ b/dominio/login/serializers.py
@@ -21,3 +21,8 @@ class DadosUsuarioSerializer(serializers.Serializer):
     nome = serializers.CharField()
     sexo = serializers.CharField()
     pess_dk = serializers.CharField()
+
+
+class DPsPIPSerializer(serializers.Serializer):
+    id_orgao = serializers.CharField()
+    dps = serializers.CharField()

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -38,6 +38,7 @@ class PermissaoUsuario:
             lista_orgaos.extend(orgaos)
 
         lista_orgaos = self._classifica_orgaos(lista_orgaos)
+        lista_orgaos = self._adiciona_cisps(lista_orgaos)
         return lista_orgaos
 
     @cached_property
@@ -78,9 +79,24 @@ class PermissaoUsuario:
             or orgao["cdorgao"] in self.pip_validas
         ]
 
+    def _adiciona_cisps(self, lista_orgaos):
+        lista_orgaos_copy = lista_orgaos.copy()
+        for orgao in lista_orgaos_copy:
+            orgao["dps"] = self._get_cisps_from_orgao(orgao["cdorgao"])
+
+        return lista_orgaos_copy
+
     @cached_property
     def pip_validas(self):
         return [r["id_orgao"] for r in dao.PIPValidasDAO.get()]
+
+    @cached_property
+    def pip_cisps(self):
+        lista_cisps = dao.ListaDPsPIPsDAO.get()
+        return {d['id_orgao']: d['dps'] for d in lista_cisps}
+
+    def _get_cisps_from_orgao(self, id_orgao):
+        return self.pip_cisps.get(id_orgao, '')
 
 
 class PermissoesUsuarioRegular(PermissaoUsuario):
@@ -104,7 +120,8 @@ class PermissoesUsuarioAdmin(PermissaoUsuario):
     @cached_property
     def todos_orgaos(self):
         lista_orgaos = dao.ListaTodosOrgaosDAO.get()
-        return self._classifica_orgaos(lista_orgaos)
+        lista_orgaos = self._classifica_orgaos(lista_orgaos)
+        return self._adiciona_cisps(lista_orgaos)
 
     @property
     def orgaos_validos(self):

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -29,7 +29,7 @@ class TestBuildLoginResponse(TestCase):
             "execute"
         )
         self.pip_cisps_mock = self.pip_cisps_dao_patcher.start()
-        self.pip_cisps_mock.return_value = [("098765", "1,2,3"),]
+        self.pip_cisps_mock.return_value = [("098765", "1,2,3"), ]
 
         self.jwt_patcher = mock.patch(
             "dominio.login.services.jwt.encode", return_value="auth-token"
@@ -246,7 +246,7 @@ class TestPermissoesUsuarioRegular(TestCase):
             "execute"
         )
         self.pip_cisps_mock = self.pip_cisps_dao_patcher.start()
-        self.pip_cisps_mock.return_value = [("098765", "1,2,3"),]
+        self.pip_cisps_mock.return_value = [("098765", "1,2,3"), ]
 
         self.oracle_access_patcher = mock.patch(
             "dominio.login.dao.oracle_access"
@@ -545,7 +545,10 @@ class TesPermissoesUsuarioAdmin(TestCase):
             "execute"
         )
         self.pip_cisps_mock = self.pip_cisps_dao_patcher.start()
-        self.pip_cisps_mock.return_value = [("cdorgao 1", "1,2,3"), ("cdorgao 4", "1,2,3")]
+        self.pip_cisps_mock.return_value = [
+            ("cdorgao 1", "1,2,3"),
+            ("cdorgao 4", "1,2,3")
+        ]
 
         self.oracle_access_patcher = mock.patch(
             "dominio.login.dao.oracle_access"

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -403,7 +403,7 @@ class TestPermissoesUsuarioRegular(TestCase):
         self.assertEqual(cisps_promotorias, self.expected)
 
     def test_pip_cisps(self):
-        response = self.permissoes.pip_cisps()
+        response = self.permissoes.pip_cisps
         expected = {"098765": "1,2,3"}
         self.assertEqual(response, expected)
 

--- a/dominio/login/tests/test_views.py
+++ b/dominio/login/tests/test_views.py
@@ -10,6 +10,7 @@ from jwt.exceptions import DecodeError
 from model_bakery.baker import make
 
 from dominio.login.integra import authenticate_integra
+from dominio.login.dao import DPsPIPDAO
 
 
 @pytest.mark.django_db(transaction=True)
@@ -109,12 +110,14 @@ class TestLoginIntegra(TestCase):
 
 
 class AuthenticateIntegraTest(TestCase):
+    @mock.patch.object(DPsPIPDAO, "get")
     @mock.patch(
         "dominio.login.integra.jwt.encode", return_value=b"encode_token"
     )
     @mock.patch("dominio.login.integra.jwt.decode")
     @mock.patch("dominio.login.integra.get_jwt_from_post")
-    def test_authenticate_integra(self, _get_jwt, _decode, _encode):
+    def test_authenticate_integra(self, _get_jwt, _decode, _encode, _get_dps):
+        _get_dps.return_value = {"dps": "12,15"}
         _decode.return_value = {
             "user_name": "user_name",
             "scaUser": {
@@ -134,6 +137,7 @@ class AuthenticateIntegraTest(TestCase):
             "nome": "nome",
             "tipo_orgao": 1,
             "matricula": "12345",
+            "dps": "12,15"
         }
         resp_payload = authenticate_integra("request")
         expected_payload = jwt_payload.copy()


### PR DESCRIPTION
Pega CISPs (DPs) da tabela tb_pip_cisp no BDA. Caso o órgão tenha CISPs associadas, retorna no atributo "dps" com o formato "1,2,3". Caso o órgão não tenha CISP associada, retorna uma string vazia "".