### PR TITLE
Feature/protege endpoints

### DIFF
--- a/dominio/alertas/views.py
+++ b/dominio/alertas/views.py
@@ -15,7 +15,7 @@ class AlertasView(JWTAuthMixin, CacheMixin, PaginatorMixin, APIView):
     # ALERTAS_SIZE = 25
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         # page = int(request.GET.get("page", 1))
         tipo_alerta = request.GET.get("tipo_alerta", None)
 
@@ -34,7 +34,7 @@ class ResumoAlertasView(JWTAuthMixin, CacheMixin, PaginatorMixin, APIView):
     cache_config = 'ALERTAS_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         alertas_resumo = dao.ResumoAlertasDAO.get_all(id_orgao=orgao_id)
 
@@ -45,6 +45,6 @@ class AlertasComprasView(JWTAuthMixin, CacheMixin, PaginatorMixin, APIView):
     cache_config = 'ALERTAS_COMPRAS_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        id_orgao = int(kwargs.get("orgao_id"))
+        id_orgao = int(kwargs.get(self.orgao_url_kwarg))
         data = dao.AlertaComprasDAO.get(id_orgao=id_orgao, accept_empty=True)
         return Response(data=data)

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -95,6 +95,13 @@ class PermissaoUsuario:
         lista_cisps = dao.ListaDPsPIPsDAO.get()
         return {d['id_orgao']: d['dps'] for d in lista_cisps}
 
+    @property
+    def ids_orgaos_lotados_validos(self):
+        return [
+            o.get("cdorgao")
+            for o in self._filtra_orgaos_invalidos(self.orgaos_lotados)
+        ]
+
     def _get_cisps_from_orgao(self, id_orgao):
         return self.pip_cisps.get(id_orgao, '')
 

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -175,6 +175,9 @@ def build_login_response(permissoes):
     response["cpf"] = permissoes.dados_usuario["cpf"]
     response["nome"] = permissoes.dados_usuario["nome"]
     response["matricula"] = permissoes.dados_usuario["matricula"]
+    response["ids_orgaos_lotados_validos"] = (
+        permissoes.ids_orgaos_lotados_validos
+    )
 
     response["token"] = jwt.encode(
         response, settings.JWT_SECRET, algorithm="HS256",

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -89,6 +89,7 @@ class TestBuildLoginResponse(TestCase):
             "sexo": "X",
             "token": "auth-token",
             "tipo_permissao": "regular",
+            "ids_orgaos_lotados_validos": ["098765", "1234"],
             "orgao_selecionado":
             {
                 "cpf": "CPF 1",

--- a/dominio/login/tests/test_services.py
+++ b/dominio/login/tests/test_services.py
@@ -339,6 +339,12 @@ class TestPermissoesUsuarioRegular(TestCase):
     def test_retorna_orgaos_de_usuario(self):
         self.assertEqual(self.permissoes.orgaos_lotados, self.expected)
 
+    def test_retorna_ids_orgaos_lotados_validos(self):
+        ids_orgaos_lotados_validos = self.permissoes.ids_orgaos_lotados_validos
+        expected_ids = ["098765", "9999"]
+
+        self.assertEqual(ids_orgaos_lotados_validos, expected_ids)
+
     def test_retorna_orgaos_VALIDOS_de_usuario(self):
         """Retorna orgaos validos (do ponto de vista do Promotron).
         Até o momento PIP e Tutela (com excessão de infância e idoso)

--- a/dominio/mixins.py
+++ b/dominio/mixins.py
@@ -55,13 +55,15 @@ class CacheMixin:
 
 
 class JWTAuthMixin:
+    orgao_url_kwarg = "orgao_id"
+
     def authorize_user_in_orgao(self, token_payload, *args, **kwargs):
         is_admin = token_payload.get("tipo_permissao", "regular") == "admin"
         orgaos = (
             token_payload.get("ids_orgaos_lotados_validos", [])
             + [token_payload.get("orgao")]
         )
-        return is_admin or kwargs.get("orgao_id") in orgaos
+        return is_admin or kwargs.get(self.orgao_url_kwarg) in orgaos
 
     def dispatch(self, request, *args, **kwargs):
         try:

--- a/dominio/mixins.py
+++ b/dominio/mixins.py
@@ -58,6 +58,7 @@ class JWTAuthMixin:
     orgao_url_kwarg = "orgao_id"
 
     def authorize_user_in_orgao(self, token_payload, *args, **kwargs):
+        # TODO: nos deveríamos aceitar POST de um admin para qualquer órgão?
         is_admin = token_payload.get("tipo_permissao", "regular") == "admin"
         orgaos = (
             token_payload.get("ids_orgaos_lotados_validos", [])

--- a/dominio/pip/views.py
+++ b/dominio/pip/views.py
@@ -17,7 +17,7 @@ class PIPDetalheAproveitamentosView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_DETALHEAPROVEITAMENTOS_CACHE_TIMEOUT"
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs["orgao_id"])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
 
         data = PIPDetalheAproveitamentosDAO.get(orgao_id=orgao_id)
         return Response(data)
@@ -27,7 +27,7 @@ class PIPVistasAbertasMensalView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_VISTASABERTASMENSAL_CACHE_TIMEOUT"
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         cpf = kwargs.get("cpf")
 
         aberturas = Vista.vistas.aberturas_30_dias_PIP(orgao_id, cpf)
@@ -49,7 +49,7 @@ class PIPSuaMesaInvestigacoesAISPView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_SUAMESAINVESTIGACOESAISP_CACHE_TIMEOUT"
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         _, orgaos_same_aisp = get_orgaos_same_aisps(orgao_id)
 
@@ -66,7 +66,7 @@ class PIPIndicadoresDeSucessoView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_INDICADORES_SUCESSO_CACHE_TIMEOUT"
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         data = PIPIndicadoresDeSucessoDAO.get(orgao_id=orgao_id)
         return Response(data=data)
 
@@ -76,7 +76,7 @@ class PIPSuaMesaInqueritosView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_SUAMESAINQUERITOS_CACHE_TIMEOUT"
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         doc_count = Documento.investigacoes.em_curso(
             orgao_id, [3, 494]
@@ -92,7 +92,7 @@ class PIPSuaMesaPICsView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_SUAMESAPICS_CACHE_TIMEOUT"
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         doc_count = Documento.investigacoes.em_curso(
             orgao_id, [590]
@@ -107,7 +107,7 @@ class PIPRadarPerformanceView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = "PIP_RADAR_PERFORMANCE_CACHE_TIMEOUT"
 
     def get(self, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         return Response(data=PIPRadarPerformanceDAO.get(orgao_id=orgao_id))
 
 
@@ -117,7 +117,7 @@ class PIPPrincipaisInvestigadosView(
     PRINCIPAIS_INVESTIGADOS_SIZE = 20
 
     def get(self, request, *args, **kwargs):
-        orgao_id = kwargs.get("orgao_id")
+        orgao_id = kwargs.get(self.orgao_url_kwarg)
         cpf = kwargs.get("cpf")
         page = int(request.GET.get("page", 1))
 
@@ -132,7 +132,7 @@ class PIPPrincipaisInvestigadosView(
         return Response(page_data)
 
     def post(self, request, *args, **kwargs):
-        orgao_id = kwargs.get("orgao_id")
+        orgao_id = kwargs.get(self.orgao_url_kwarg)
         cpf = kwargs.get("cpf")
 
         # TODO: Verificar que o post foi feito pelo mesmo orgao

--- a/dominio/tests/helpers.py
+++ b/dominio/tests/helpers.py
@@ -7,3 +7,6 @@ from dominio.mixins import JWTAuthMixin
 class SecureView(JWTAuthMixin, APIView):
     def get(self, request, *args, **kwargs):
         return Response(data={})
+
+    def post(self, request, *args, **kwargs):
+        return Response(data={})

--- a/dominio/tests/helpers.py
+++ b/dominio/tests/helpers.py
@@ -1,0 +1,9 @@
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from dominio.mixins import JWTAuthMixin
+
+
+class SecureView(JWTAuthMixin, APIView):
+    def get(self, request, *args, **kwargs):
+        return Response(data={})

--- a/dominio/tests/test_mixins.py
+++ b/dominio/tests/test_mixins.py
@@ -260,3 +260,39 @@ class TestJWTAuthMixinValidateRequestOrgao(TestCase):
         )
 
         self.assertEqual(response.status_code, 403)
+
+    def test_authorize_orgao_in_POST_request_success(self):
+        id_orgao = "12345"
+        jwt_payload = {
+            "orgao": id_orgao,
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().post(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(request, orgao_id=id_orgao)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_authorize_orgao_in_POST_request_forbidden(self):
+        id_orgao_request = "12345"
+        id_orgao_token = "65432"
+        jwt_payload = {
+            "orgao": id_orgao_token,
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().post(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(
+            request,
+            orgao_id=id_orgao_request
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/dominio/tests/test_mixins.py
+++ b/dominio/tests/test_mixins.py
@@ -1,11 +1,14 @@
-from unittest import mock, TestCase
+from unittest import mock
 
+import jwt
 from django.conf import settings
 from django.core.paginator import EmptyPage
 from django.http import HttpResponseForbidden
+from django.test import RequestFactory, TestCase
 from jwt import DecodeError
 
 from dominio.mixins import CacheMixin, JWTAuthMixin, PaginatorMixin
+from dominio.tests import helpers
 
 
 class TestMixins(TestCase):
@@ -144,3 +147,116 @@ class TestJWTMixin(TestCase):
 
         _unpack_jwt.assert_called_once_with('request')
         self.assertTrue(isinstance(handler, HttpResponseForbidden))
+
+
+class TestJWTAuthMixinValidateRequestOrgao(TestCase):
+    def test_jwt_admin_with_same_orgao_in_request(self):
+        id_orgao = "12345"
+        jwt_payload = {
+            "tipo_permissao": "admin",
+            "ids_orgaos_lotados_validos": [id_orgao],
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().get(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(request, orgao_id=id_orgao)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_jwt_admin_with_different_orgao_in_request(self):
+        id_orgao_request = "12345"
+        id_orgao_token = "65432"
+        jwt_payload = {
+            "tipo_permissao": "admin",
+            "ids_orgaos_lotados_validos": [id_orgao_token],
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().get(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(
+            request, orgao_id=id_orgao_request
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_jwt_regular_with_same_orgao_in_request(self):
+        id_orgao = "12345"
+        jwt_payload = {
+            "tipo_permissao": "regular",
+            "ids_orgaos_lotados_validos": [id_orgao],
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().get(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(request, orgao_id=id_orgao)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_jwt_regular_with_different_orgao_in_request(self):
+        id_orgao_request = "12345"
+        id_orgao_token = "65432"
+        jwt_payload = {
+            "tipo_permissao": "regular",
+            "ids_orgaos_lotados_validos": [id_orgao_token],
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().get(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(
+            request,
+            orgao_id=id_orgao_request
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_jwt_integra_with_same_orgao_in_request(self):
+        id_orgao = "12345"
+        jwt_payload = {
+            "orgao": id_orgao,
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().get(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(request, orgao_id=id_orgao)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_jwt_integra_with_different_orgao_in_request(self):
+        id_orgao_request = "12345"
+        id_orgao_token = "65432"
+        jwt_payload = {
+            "orgao": id_orgao_token,
+        }
+        token = jwt.encode(
+            jwt_payload,
+            settings.JWT_SECRET,
+            algorithm="HS256"
+        ).decode()
+
+        request = RequestFactory().get(f"/fake?jwt={token}")
+        response = helpers.SecureView.as_view()(
+            request,
+            orgao_id=id_orgao_request
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/dominio/tests/testconf.py
+++ b/dominio/tests/testconf.py
@@ -2,16 +2,25 @@ from unittest import mock
 
 from django.core.cache import cache
 
+from dominio.mixins import JWTAuthMixin
+
 
 class NoJWTTestCase:
     def setUp(self):
         self.mock_jwt = mock.patch('dominio.mixins.unpack_jwt')
+        self.mock_authorize_in_orgao = mock.patch.object(
+            JWTAuthMixin,
+            "authorize_user_in_orgao"
+        )
         super().setUp()
         self.mock_jwt.start()
+        self.mocked_authorize = self.mock_authorize_in_orgao.start()
+        self.mocked_authorize.return_value = True
 
     def tearDown(self):
         super().tearDown()
         self.mock_jwt.stop()
+        self.mock_authorize_in_orgao.stop()
 
 
 class NoCacheTestCase:

--- a/dominio/tutela/views.py
+++ b/dominio/tutela/views.py
@@ -79,7 +79,7 @@ class DetalheAcervoView(JWTAuthMixin, CacheMixin, APIView):
         return run_query(query, parameters)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
 
         date_today = datetime.now().date()
         dt_fim = str(date_today)
@@ -158,7 +158,7 @@ class OutliersView(JWTAuthMixin, CacheMixin, APIView):
         return run_query(query, parameters)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
 
         data = self.get_data(
             orgao_id=orgao_id
@@ -192,7 +192,7 @@ class SaidasView(JWTAuthMixin, CacheMixin, APIView):
         return run_query(query, parameters)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
 
         data = self.get_saidas(
             orgao_id=orgao_id
@@ -246,7 +246,7 @@ class EntradasView(JWTAuthMixin, CacheMixin, APIView):
         return run_query(query, parameters)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
         nr_cpf = str(self.kwargs['nr_cpf'])
 
         data = self.get_entradas(
@@ -281,7 +281,7 @@ class SuaMesaVistasAbertas(JWTAuthMixin, CacheMixin, APIView):
     cache_config = 'SUAMESAVISTAS_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         cpf = kwargs.get("cpf")
 
         doc_count = Vista.vistas.abertas_promotor(orgao_id, cpf).count()
@@ -294,7 +294,7 @@ class SuaMesaInvestigacoes(JWTAuthMixin, CacheMixin, APIView):
     cache_config = 'SUAMESAINVESTIGACOES_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         regras_investigacoes = suamesa.get_regras(
             orgao_id,
@@ -311,7 +311,7 @@ class SuaMesaProcessos(JWTAuthMixin, CacheMixin, APIView):
     cache_config = 'SUAMESAPROCESSOS_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         regras_processos = suamesa.get_regras(orgao_id, tipo='processo')
         doc_count = Documento.processos.em_juizo(
@@ -325,7 +325,7 @@ class SuaMesaFinalizados(JWTAuthMixin, CacheMixin, APIView):
     cache_config = 'SUAMESAFINALIZADOS_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
 
         regras_saidas = (6251, 6657, 6655, 6644, 6326)
         regras_arquiv = (7912, 6548, 6326, 6681, 6678, 6645, 6682, 6680, 6679,
@@ -351,7 +351,7 @@ class SuaMesaDetalheView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = 'SUAMESADETALHE_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         cpf = kwargs.get("cpf")
 
         mesa_detalhe = Vista.vistas.agg_abertas_por_data(orgao_id, cpf)
@@ -386,7 +386,7 @@ class DetalheProcessosJuizoView(JWTAuthMixin, CacheMixin, APIView):
         return run_query(query, parameters)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
 
         data_acoes = self.get_numero_acoes_propostas_pacote_atribuicao(
             orgao_id=orgao_id
@@ -422,7 +422,7 @@ class SuaMesaVistasListaView(
     cache_config = 'SUAMESAVISTASLISTA_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(kwargs.get("orgao_id"))
+        orgao_id = int(kwargs.get(self.orgao_url_kwarg))
         cpf = kwargs.get("cpf")
         abertura = kwargs.get("abertura")
         lista_aberturas = ("ate_vinte", "vinte_trinta", "trinta_mais")
@@ -456,7 +456,7 @@ class TempoTramitacaoView(JWTAuthMixin, CacheMixin, APIView):
     cache_config = 'TEMPO_TRAMITACAO_CACHE_TIMEOUT'
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
         version = self.request.GET.get('version')
 
         if version == '1.1':
@@ -499,7 +499,7 @@ class DesarquivamentosView(JWTAuthMixin, CacheMixin, APIView):
             return self.fetch_set(result_set)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
         # TODO: pensar numa forma geral de discernir 404 de respostas
         # vazias e respostas não existentes
 
@@ -521,7 +521,7 @@ class ListaProcessosView(JWTAuthMixin, CacheMixin, PaginatorMixin, APIView):
         return run_query(query, parameters)
 
     def get(self, request, *args, **kwargs):
-        orgao_id = int(self.kwargs['orgao_id'])
+        orgao_id = int(self.kwargs.get(self.orgao_url_kwarg))
         page = int(request.GET.get("page", 1))
 
         data = self.get_data(orgao_id)


### PR DESCRIPTION
Protege endpoints para requisições de outros órgãos que não estão autorizados no payload do JWT.

- Adicionamos o campo `ids_orgaos_validos_lotados` no payload do Token de login SCA
- Usuários admin podem fazer requisições em qualquer endpoint para qualquer órgão
- Usuários regulares somente tem acessos aos órgãos válidos que estão lotados.


**Ponto de atenção**:
Podemos permitir `POST` de um usuário admin em um órgão qualquer?