### PR TITLE
Muda rankings de PICs

### DIFF
--- a/dominio/suamesa/dao.py
+++ b/dominio/suamesa/dao.py
@@ -67,8 +67,11 @@ class SuaMesaDetalhePIPInqueritosDAO(
 
 
 class SuaMesaDetalhePIPPICSDAO(
-       RankingPercentageMixin, MetricsDetalheDocumentoOrgaoCPFDAO):
-    ranking_fields = ['variacao_documentos_distintos']
+       RankingMixin, MetricsDetalheDocumentoOrgaoCPFDAO):
+    ranking_fields = [
+        'acervo_fim',
+        'nr_instaurados_atual'
+    ]
 
 
 class SuaMesaDetalhePIPAISPDAO(RankingMixin, MetricsDetalheDocumentoOrgaoDAO):

--- a/dominio/suamesa/dao_rankings.py
+++ b/dominio/suamesa/dao_rankings.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 from django.conf import settings
 
 from dominio.suamesa.serializers import (
@@ -72,10 +74,15 @@ class RankingMixin:
         }
 
         data = []
+        # ranking_dao pode ser uma lista, um dao para cada ranking_field
+        if not isinstance(cls.ranking_dao, list):
+            ranking_list = product(cls.ranking_fields, [cls.ranking_dao])
+        else:
+            ranking_list = zip(cls.ranking_fields, cls.ranking_dao)
 
-        for fieldname in cls.ranking_fields:
-            ranking_dao = cls.ranking_dao(fieldname)
-            response = ranking_dao.get(accept_empty=accept_empty, **kwargs)
+        for fieldname, ranking_dao in ranking_list:
+            dao = ranking_dao(fieldname)
+            response = dao.get(accept_empty=accept_empty, **kwargs)
             if response:
                 data.append({'ranking_fieldname': fieldname, 'data': response})
 

--- a/dominio/suamesa/queries/ranking_pics_aumentos.sql
+++ b/dominio/suamesa/queries/ranking_pics_aumentos.sql
@@ -1,0 +1,12 @@
+SELECT orgi_nm_orgao, {nm_campo} 
+FROM {schema}.tb_detalhe_documentos_orgao
+WHERE tipo_detalhe = :tipo_detalhe
+AND intervalo = :intervalo
+AND cod_pct IN (
+    SELECT cod_pct
+    FROM {schema}.atualizacao_pj_pacote
+    WHERE id_orgao = :orgao_id)
+AND {nm_campo} IS NOT NULL
+AND {nm_campo} > 0
+ORDER BY {nm_campo} DESC
+LIMIT :n

--- a/dominio/suamesa/queries/ranking_pics_reducoes.sql
+++ b/dominio/suamesa/queries/ranking_pics_reducoes.sql
@@ -1,0 +1,12 @@
+SELECT orgi_nm_orgao, {nm_campo} 
+FROM {schema}.tb_detalhe_documentos_orgao
+WHERE tipo_detalhe = :tipo_detalhe
+AND intervalo = :intervalo
+AND cod_pct IN (
+    SELECT cod_pct
+    FROM {schema}.atualizacao_pj_pacote
+    WHERE id_orgao = :orgao_id)
+AND {nm_campo} IS NOT NULL
+AND {nm_campo} < 0
+ORDER BY {nm_campo} ASC
+LIMIT :n


### PR DESCRIPTION
No caso de ter mais de um ranking, agora é possível passar uma lista de DAOs a serem aplicados, um por ranking. Senão, o mesmo DAO será passado para todos.

Queries .sql foram feitas para o aumento/redução de acervo de PICs, porém esse requisito mudou, então elas não são utilizadas, mas as queries foram mantidas por questão de registro.