### PR TITLE
Fix/todas pips

### DIFF
--- a/dominio/pip/dao.py
+++ b/dominio/pip/dao.py
@@ -127,6 +127,7 @@ class PIPRadarPerformanceDAO(GenericPIPDAO):
         "nm_max_acordos",
         "nm_max_arquivamentos",
         "nm_max_abeturas_vista",
+        "cod_pct"
     ]
     table_namespaces = {"schema": settings.TABLE_NAMESPACE}
 

--- a/dominio/pip/tests/test_dao.py
+++ b/dominio/pip/tests/test_dao.py
@@ -32,13 +32,13 @@ class TestPIPDetalheAproveitamentosDAO:
             (5, "TC 5", 40, 30, 0.75, 30),
         ]
         _run_query_aisps.return_value = [
-            (1, 1, "AISP1"),
-            (1, 2, "AISP2"),
-            (2, 1, "AISP1"),
-            (2, 2, "AISP2"),
-            (3, 3, "AISP3"),
-            (4, 3, "AISP3"),
-            (5, 3, "AISP3"),
+            (1, 1, "AISP1", 200),
+            (1, 2, "AISP2", 200),
+            (2, 1, "AISP1", 200),
+            (2, 2, "AISP2", 200),
+            (3, 3, "AISP3", 200),
+            (4, 3, "AISP3", 200),
+            (5, 3, "AISP3", 200),
         ]
 
         get_aisps.cache_clear()

--- a/dominio/pip/tests/test_dao.py
+++ b/dominio/pip/tests/test_dao.py
@@ -117,6 +117,7 @@ class TestPIPRadarPerformance:
                 "3ª PROMOTORIA DE JUSTIÇA",
                 "4ª PROMOTORIA DE JUSTIÇa",
                 "5ª PROMOTORIA DE JUSTIÇA",
+                200,
             ),
         ]
         ser_data = PIPRadarPerformanceDAO.serialize(result_set)
@@ -155,6 +156,7 @@ class TestPIPRadarPerformance:
             "nm_max_acordos": "3ª Promotoria de Justiça",
             "nm_max_arquivamentos": "4ª Promotoria de Justiça",
             "nm_max_abeturas_vista": "5ª Promotoria de Justiça",
+            "cod_pct": 200,
         }
         assert ser_data == expected_data
 

--- a/dominio/pip/tests/test_utils.py
+++ b/dominio/pip/tests/test_utils.py
@@ -13,13 +13,15 @@ class UtilsPIPTest(TestCase):
     @mock.patch("dominio.pip.utils.run_query")
     def test_get_orgaos_same_aisps(self, _run_query):
         _run_query.return_value = [
-            (1, 1, "AISP1"),
-            (1, 2, "AISP2"),
-            (2, 1, "AISP1"),
-            (2, 2, "AISP2"),
-            (3, 3, "AISP3"),
-            (4, 3, "AISP3"),
-            (5, 3, "AISP3"),
+            (1, 1, "AISP1", 200),
+            (1, 2, "AISP2", 200),
+            (2, 1, "AISP1", 200),
+            (2, 2, "AISP2", 200),
+            (3, 3, "AISP3", 200),
+            (4, 3, "AISP3", 200),
+            (5, 3, "AISP3", 200),
+            (6, 1, "AISP1", 201),
+            (6, 2, "AISP2", 201)
         ]
 
         orgao_id_test = 1

--- a/dominio/pip/tests/test_views.py
+++ b/dominio/pip/tests/test_views.py
@@ -66,13 +66,13 @@ class PIPInvestigacoesCursoAISPTest(NoJWTTestCase, NoCacheTestCase, TestCase):
     @mock.patch("dominio.pip.views.Documento")
     def test_pip_investigacoes_curso_aisp(self, _Documento, _run_query_aisps):
         _run_query_aisps.return_value = [
-            (1, 1, "AISP1"),
-            (1, 2, "AISP2"),
-            (2, 1, "AISP1"),
-            (2, 2, "AISP2"),
-            (3, 3, "AISP3"),
-            (4, 3, "AISP3"),
-            (5, 3, "AISP3"),
+            (1, 1, "AISP1", 200),
+            (1, 2, "AISP2", 200),
+            (2, 1, "AISP1", 200),
+            (2, 2, "AISP2", 200),
+            (3, 3, "AISP3", 200),
+            (4, 3, "AISP3", 200),
+            (5, 3, "AISP3", 200),
         ]
 
         manager_mock = mock.MagicMock()

--- a/dominio/pip/utils.py
+++ b/dominio/pip/utils.py
@@ -11,11 +11,14 @@ def get_aisps():
     """Retorna as AISPs de cada PIP, na seguinte ordem:
     (codigo_pip, codigo_aisp, nome_aisp)
     """
-    query = "SELECT * FROM {namespace}.tb_pip_aisp".format(
+    query = """
+        SELECT pip_codigo, aisp_codigo, aisp_nome, cod_pct 
+        FROM {namespace}.tb_pip_aisp
+        JOIN {namespace}.atualizacao_pj_pacote ON pip_codigo = id_orgao
+    """.format(
         namespace=settings.TABLE_NAMESPACE
     )
     return run_query(query)
-
 
 def get_orgaos_same_aisps(orgao_id):
     """Retorna os órgãos que pertencem às mesmas AISPs de orgao_id, por AISP.
@@ -27,8 +30,11 @@ def get_orgaos_same_aisps(orgao_id):
         list(dict) -- Lista de dicionários contendo o número da AISP e .
     """
     data = get_aisps()
+    cod_pct_current_orgao = [x[3] for x in data if x[0] == orgao_id][0]
     aisps_current_orgao = set(x[1] for x in data if x[0] == orgao_id)
-    orgaos_same_aisps = set(x[0] for x in data if x[1] in aisps_current_orgao)
+    orgaos_same_aisps = set(
+        x[0] for x in data
+        if x[1] in aisps_current_orgao and x[3] == cod_pct_current_orgao)
 
     return aisps_current_orgao, orgaos_same_aisps
 

--- a/dominio/pip/utils.py
+++ b/dominio/pip/utils.py
@@ -12,13 +12,14 @@ def get_aisps():
     (codigo_pip, codigo_aisp, nome_aisp)
     """
     query = """
-        SELECT pip_codigo, aisp_codigo, aisp_nome, cod_pct 
+        SELECT pip_codigo, aisp_codigo, aisp_nome, cod_pct
         FROM {namespace}.tb_pip_aisp
         JOIN {namespace}.atualizacao_pj_pacote ON pip_codigo = id_orgao
     """.format(
         namespace=settings.TABLE_NAMESPACE
     )
     return run_query(query)
+
 
 def get_orgaos_same_aisps(orgao_id):
     """Retorna os órgãos que pertencem às mesmas AISPs de orgao_id, por AISP.

--- a/dominio/suamesa/queries/ranking_documento_aisp.sql
+++ b/dominio/suamesa/queries/ranking_documento_aisp.sql
@@ -10,6 +10,10 @@ FROM (
     JOIN {schema}.tb_pip_aisp ON pip_codigo = vist_orgi_orga_dk
     WHERE tipo_detalhe IN ('pip_inqueritos', 'pip_pics')
     AND intervalo = :intervalo
+    AND cod_pct IN (
+        SELECT cod_pct
+        FROM {schema}.atualizacao_pj_pacote
+        WHERE id_orgao = :orgao_id)
     GROUP BY aisp_nome
     ) t
 GROUP BY pmax


### PR DESCRIPTION
Cálculos de AISPs agora levam em conta também o pacote do órgão.
Radar de Performance da PIP recebe o código do pacote junto.