### PR TITLE
Cabeçalho do Perfil do Investigado agora agrega informações dos vário…

### DIFF
--- a/dominio/pip/dao.py
+++ b/dominio/pip/dao.py
@@ -16,6 +16,7 @@ from dominio.pip.serializers import (
     PIPPrincipaisInvestigadosPerfilSerializer,
 )
 
+from dominio.utils import is_valid_cpf, is_valid_rg
 from dominio.dao import GenericDAO
 
 
@@ -247,6 +248,26 @@ class PIPPrincipaisInvestigadosPerfilDAO(GenericPIPDAO):
         ]
 
         return ser_data
+
+    @classmethod
+    def get_header_info(cls, data):
+        if not data:
+            return {}
+
+        header = data[0].copy()
+        header['pess_dk'] = None
+        header['cpf'] = header['cpf'] if is_valid_cpf(header['cpf']) else None
+        header['rg'] = header['rg'] if is_valid_rg(header['rg']) else None
+        for profile in data:
+            if not header['nm_mae']:
+                header['nm_mae'] = profile['nm_mae']
+            if not header['dt_nasc']:
+                header['dt_nasc'] = profile['dt_nasc']
+            if not header['cpf'] and is_valid_cpf(profile['cpf']):
+                header['cpf'] = profile['cpf']
+            if not header['rg'] and is_valid_rg(profile['rg']):
+                header['rg'] = profile['rg']
+        return header
 
 
 class PIPPrincipaisInvestigadosListaDAO(GenericPIPDAO):

--- a/dominio/pip/tests/test_dao.py
+++ b/dominio/pip/tests/test_dao.py
@@ -569,3 +569,45 @@ class TestPIPPrincipaisInvestigadosPerfilDAO:
             "cnpj": "123456"
         }]
         assert ser_data == expected_data
+
+    def test_get_header_info(self):
+        data = [
+            {
+                "pess_dk": 1,
+                "nm_investigado": "FULANO DE TAL",
+                "nm_mae": "CICLANA DE TAL",
+                "cpf": "1234",
+                "rg": "62718558-0",
+                "dt_nasc": None
+            },
+            {
+                "pess_dk": 2,
+                "nm_investigado": "FULANO DE T",
+                "nm_mae": "CICLANA DE TAL",
+                "cpf": None,
+                "rg": "1234",
+                "dt_nasc": "1970-01-01T00:00:00Z"
+            },
+            {
+                "pess_dk": 3,
+                "nm_investigado": "FULANO DE TAL",
+                "nm_mae": "CICLANA DE TAL",
+                "cpf": "123.456.789-01",
+                "rg": None,
+                "dt_nasc": "1970-01-01T00:00:00Z"
+            },
+        ]
+        expected_output = {
+            "pess_dk": None,
+            "nm_investigado": "FULANO DE TAL",
+            "nm_mae": "CICLANA DE TAL",
+            "cpf": "123.456.789-01",
+            "rg": "62718558-0",
+            "dt_nasc": "1970-01-01T00:00:00Z"
+        }
+        output = PIPPrincipaisInvestigadosPerfilDAO.get_header_info(data)
+        assert output == expected_output
+
+    def test_get_header_info_no_data(self):
+        output = PIPPrincipaisInvestigadosPerfilDAO.get_header_info([])
+        assert output == {}

--- a/dominio/pip/tests/test_views.py
+++ b/dominio/pip/tests/test_views.py
@@ -108,10 +108,13 @@ class TestPIPPrincipaisInvestigadosView(
 
 class TestPIPPrincipaisInvestigadosListaView(
         NoJWTTestCase, NoCacheTestCase, TestCase):
+    @mock.patch("dominio.pip.views."
+                "PIPPrincipaisInvestigadosPerfilDAO.get_header_info")
     @mock.patch("dominio.pip.views.PIPPrincipaisInvestigadosPerfilDAO.get")
     @mock.patch("dominio.pip.views.PIPPrincipaisInvestigadosListaDAO.get")
-    def test_correct_response(self, _get_procedimentos, _get_perfil):
+    def test_correct_response(self, _get_procedimentos, _get_perfil, _header):
         _get_perfil.return_value = [{"data": 1}]
+        _header.return_value = {"data": 1}
         _get_procedimentos.return_value = [{"data": 1}, {"data": 2}]
         expected_output = {
             "perfil": {"data": 1},

--- a/dominio/pip/views.py
+++ b/dominio/pip/views.py
@@ -80,7 +80,7 @@ class PIPPrincipaisInvestigadosListaView(
         pess_dk = int(request.GET.get("pess_dk", 0))
 
         similares = PIPPrincipaisInvestigadosPerfilDAO.get(dk=representante_dk)
-        perfil = similares[0] if similares else {}
+        perfil = PIPPrincipaisInvestigadosPerfilDAO.get_header_info(similares)
         procedimentos = PIPPrincipaisInvestigadosListaDAO.get(
             dk=representante_dk, pess_dk=pess_dk
         )

--- a/dominio/tests/test_utils.py
+++ b/dominio/tests/test_utils.py
@@ -7,6 +7,8 @@ from dominio.utils import (
     check_literal_eval,
     hbase_encode_row,
     hbase_decode_row,
+    is_valid_cpf,
+    is_valid_rg,
 )
 
 
@@ -119,3 +121,19 @@ class UtilsTest(TestCase):
         decoded_data = hbase_decode_row(encoded_data)
 
         self.assertEqual(data, decoded_data)
+
+    def test_is_valid_cpf(self):
+        self.assertEqual(is_valid_cpf('00000000000'), False)
+        self.assertEqual(is_valid_cpf(None), False)
+        self.assertEqual(is_valid_cpf('12345678901'), True)
+        self.assertEqual(is_valid_cpf('123.456.789-01'), True)
+        self.assertEqual(is_valid_cpf('12345'), False)
+        self.assertEqual(is_valid_cpf('12345-78901'), False)
+
+    def test_is_valid_rg(self):
+        self.assertEqual(is_valid_rg('000000000'), False)
+        self.assertEqual(is_valid_rg(None), False)
+        self.assertEqual(is_valid_rg('123456789'), True)
+        self.assertEqual(is_valid_rg('12.345.678-9'), True)
+        self.assertEqual(is_valid_rg('12345'), False)
+        self.assertEqual(is_valid_rg('12345.789'), False)

--- a/dominio/utils.py
+++ b/dominio/utils.py
@@ -1,3 +1,4 @@
+import re
 from ast import literal_eval
 
 
@@ -104,3 +105,19 @@ def hbase_decode_row(data, encoding='utf-8'):
         for key, value in data[1].items()
     }
     return decoded_key, decoded_data
+
+
+def is_valid_cpf(cpf):
+    """Recebe um CPF e diz se ele é um número válido. Precisa ser string!"""
+    if isinstance(cpf, str):
+        cleaned_cpf = re.sub('[^0-9]', '', cpf)
+        return len(cleaned_cpf) == 11 and cleaned_cpf != '00000000000'
+    return False
+
+
+def is_valid_rg(rg):
+    """Recebe um RG e diz se ele é um número válido. Precisa ser string!"""
+    if isinstance(rg, str):
+        cleaned_rg = re.sub('[^0-9]', '', rg)
+        return len(cleaned_rg) == 9 and cleaned_rg != '000000000'
+    return False


### PR DESCRIPTION
…s perfis disponíveis.

Inicialmente, o cabeçalho é preenchido com os dados do pess_dk mais antigo (porém, se o CPF ou RG forem inválidos, eles são retirados das informações iniciais). Em seguida, é feita uma iteração em cima de cada uma das pessoas disponíveis, preenchendo os campos faltantes. No caso do CPF/RG, o campo só é preenchido no cabeçalho caso o CPF/RG esteja em um formato válido.