### PR TITLE
Feature/revisao login

### DIFF
--- a/dominio/login/queries/lista_orgaos.sql
+++ b/dominio/login/queries/lista_orgaos.sql
@@ -1,24 +1,18 @@
-select
-	h.cdorgao as cdorgao,
-	o.ORGI_NM_ORGAO as nm_org,
-    rhf.cdmatricula as matricula,
-    rhf.cpf,
-    rhf.nmfuncionario as nome,
-    rhf.SEXO as sexo,
-    rhf.PESF_PESS_DK as pess_dk
-from hist_func h
-	join MPRJ_VW_FUNCIONARIO f on f.cdmatricula = h.cdmatricula
-	join RH_FUNCIONARIO rhf on rhf.CDMATRICULA = h.cdmatricula
-	join ORGI_ORGAO o on o.ORGI_CDORGAO = h.cdorgao
-	left join ORGI_GRUPO_PREF grp ON o.ORGI_GRPF_DK = grp.GRPF_DK
-where rhf.E_MAIL1 = LOWER(TRIM(:login))                           -- Matrícula igual à procurada
-	  and (dtfimexerreal is null or dtfimexerreal > sysdate)      -- Data de saída no futuro ou não informada
-	  and (o.ORGI_DT_FIM is null or o.ORGI_DT_FIM > sysdate)      -- Data de extinção do órgão no futuro ou não informada
-	  and ((f.CDTIPFUNC = 1                                       -- Que seja MP_ATIVO
-			and h.CDMOTIVOINI not in ('AS')                       -- Cujo motivo de início não seja AS
-			and (h.obs is null or (                               -- E que caso tenha observações, elas não contenham
-				lower(h.obs) not like '%exclusivamente%'          -- as palavras 'exclusivamente' e 'especificamente'
-				and lower(h.obs) not like '%especificamente%'
-			))) or (f.CDTIPFUNC <> 1))                            -- Ou que não seja MP_ATIVO
-
-GROUP BY h.cdorgao, o.ORGI_NM_ORGAO, rhf.cdmatricula, rhf.cpf, rhf.nmfuncionario, rhf.SEXO, rhf.PESF_PESS_DK
+SELECT
+	hist.cdorgao as cdorgao,
+	orgi.ORGI_NM_ORGAO as nm_org,
+    func.cdmatricula as matricula,
+    func.cpf,
+    func.nmfuncionario as nome,
+    func.SEXO as sexo,
+    func.PESF_PESS_DK as pess_dk
+FROM rh.HIST_FUNC hist
+    JOIN rh_funcionario func ON func.cdmatricula = hist.cdmatricula
+    JOIN orgi_orgao orgi ON cast(hist.cdorgao as INT) = orgi.orgi_dk
+    JOIN rh.tipo_funcionario tf ON tf.cdtipfunc = func.CDTIPFUNC 
+WHERE func.E_MAIL1 = LOWER(TRIM(:login))
+    AND (hist.dtfimexerreal IS NULL OR hist.dtfimexerreal >= SYSDATE)
+    AND orgi.orgi_tpor_dk = 1
+    AND func.CDSITUACAOFUNC = '1'
+    AND func.CDTIPFUNC = 1 -- APENAS PROMOTOR
+	AND tf.sit_func = 'A'

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -209,7 +209,7 @@ def build_login_response(permissoes):
 
     # Informações dos órgãos
     response["orgao_selecionado"] = permissoes.orgao_selecionado
-    response["orgaos_lotados"] = permissoes.orgaos_lotados
+    response["orgaos_lotados"] = permissoes.orgaos_lotados # TODO Verificar se pode ser removido
     response["orgaos_validos"] = permissoes.orgaos_validos
 
     # Update last_login

--- a/dominio/login/services.py
+++ b/dominio/login/services.py
@@ -209,7 +209,8 @@ def build_login_response(permissoes):
 
     # Informações dos órgãos
     response["orgao_selecionado"] = permissoes.orgao_selecionado
-    response["orgaos_lotados"] = permissoes.orgaos_lotados # TODO Verificar se pode ser removido
+    response["orgaos_lotados"] = permissoes.orgaos_lotados
+    # TODO Verificar se orgaos_lotados pode ser removido
     response["orgaos_validos"] = permissoes.orgaos_validos
 
     # Update last_login


### PR DESCRIPTION
Alteração da query de login para conformar com o diagnóstico de promotorias

Cogitamos deprecar a variável orgaos_lotados e trabalhar apenas com orgaos_validos, uma vez que o front parece não parece usar
Usamos a condição tipo_funcionario.sit_func = 'A' para garantir a validade dos funcionários. Vale checar com os mais sábios se essa informação procede.