### PR TITLE
Corrige bug de duplicação de procedimentos

### DIFF
--- a/dominio/pip/dao.py
+++ b/dominio/pip/dao.py
@@ -330,6 +330,8 @@ class PIPPrincipaisInvestigadosListaDAO(GenericPIPDAO):
         pess_dk = kwargs.get("pess_dk")
         if pess_dk:
             data = [x for x in data if x['pess_dk'] == pess_dk]
+        else:
+            data = list({x['documento_nr_mp']: x for x in data}.values())
         return data
 
 

--- a/dominio/pip/tests/test_dao.py
+++ b/dominio/pip/tests/test_dao.py
@@ -428,16 +428,6 @@ class TestPIPPrincipaisInvestigadosListaDAO:
         ]
         expected = [
             {
-                "pess_dk": 16,
-                "coautores": "Nome",
-                "documento_nr_mp": "123456",
-                "nm_orgao": "5ª Promotoria de Justiça",
-                "assuntos": ["Assunto 1", "Assunto 2"],
-                "fase_documento": "FaseDoc",
-                "dt_ultimo_andamento": '2020-04-22T13:36:06.668000Z',
-                "desc_ultimo_andamento": "Andamento 1",
-            },
-            {
                 "pess_dk": 1,
                 "coautores": "Nome",
                 "documento_nr_mp": "123456",


### PR DESCRIPTION
Caso o pess_dk não esteja definido, ele tira os procedimentos duplicados da resposta.

(Ele irá retornar o procedimento associado ao primeiro pess_dk que aparecer nos dados, porém, isso não é importante, pois esta informação não é mostrada para o usuário final).