### PR TITLE
Alterações no back para comportar novo alerta ISPS

### DIFF
--- a/dominio/alertas/dao.py
+++ b/dominio/alertas/dao.py
@@ -134,6 +134,8 @@ class AlertaMGPDAO(AlertasDAO):
         "dias_passados",
         "id_alerta",
         "sigla",
+        "descricao",
+        "classe_hierarquia"
     ]
 
     @classmethod

--- a/dominio/alertas/helper.py
+++ b/dominio/alertas/helper.py
@@ -5,6 +5,7 @@ ordem = [
     'PRCR3',
     'PRCR4',
     'COMP',
+    'ISPS',
     'GATE',
     'MCSI',
     'MVVD',

--- a/dominio/alertas/queries/validos_por_orgao_base.sql
+++ b/dominio/alertas/queries/validos_por_orgao_base.sql
@@ -4,7 +4,9 @@ alrt_docu_date,
 alrt_orgi_orga_dk,
 alrt_dias_passados,
 alrt_dk,
-alrt_sigla
+alrt_sigla,
+alrt_descricao,
+alrt_classe_hierarquia
 FROM {schema}.mmps_alertas alrt
 where alrt.dt_partition = :dt_partition
 AND alrt.alrt_orgi_orga_dk = :orgao_id

--- a/dominio/alertas/queries/validos_por_orgao_tipo.sql
+++ b/dominio/alertas/queries/validos_por_orgao_tipo.sql
@@ -4,7 +4,9 @@ alrt_docu_date,
 alrt_orgi_orga_dk,
 alrt_dias_passados,
 alrt_dk,
-alrt_sigla
+alrt_sigla,
+alrt_descricao,
+alrt_classe_hierarquia
 FROM {schema}.mmps_alertas alrt
 where alrt.dt_partition = :dt_partition
     AND alrt.alrt_orgi_orga_dk = :orgao_id

--- a/dominio/alertas/serializers.py
+++ b/dominio/alertas/serializers.py
@@ -9,6 +9,8 @@ class AlertasListaSerializer(serializers.Serializer):
     data_alerta = serializers.DateTimeField()
     orgao = serializers.IntegerField()
     dias_passados = serializers.IntegerField()
+    descricao = serializers.CharField()
+    classe_hierarquia = serializers.CharField()
 
 
 class AlertasResumoSerializer(serializers.Serializer):

--- a/dominio/alertas/tests/test_alertas.py
+++ b/dominio/alertas/tests/test_alertas.py
@@ -24,7 +24,9 @@ class AlertaListaTest(NoJWTTestCase, NoCacheTestCase, TestCase):
                 'data_alerta': datetime(2020, 1, 1),
                 'orgao': int(orgao_id),
                 'id_alerta': 'id_alrt',
-                'dias_passados': -1
+                'dias_passados': -1,
+                'descricao': 'desc1',
+                'classe_hierarquia': 'classe1'
             },
         ]
 
@@ -36,7 +38,9 @@ class AlertaListaTest(NoJWTTestCase, NoCacheTestCase, TestCase):
                 'data_alerta': '2020-01-01T00:00:00Z',
                 'orgao': 0,
                 'id_alerta': 'id_alrt',
-                'dias_passados': -1
+                'dias_passados': -1,
+                'descricao': 'desc1',
+                'classe_hierarquia': 'classe1'
             }
         ]
 
@@ -64,7 +68,9 @@ class AlertaListaTest(NoJWTTestCase, NoCacheTestCase, TestCase):
                 'data_alerta': datetime(2020, 1, 1),
                 'orgao': int(orgao_id),
                 'id_alerta': 'id_alrt',
-                'dias_passados': -1
+                'dias_passados': -1,
+                'descricao': 'desc1',
+                'classe_hierarquia': 'classe1'
             },
         ]
 
@@ -76,7 +82,9 @@ class AlertaListaTest(NoJWTTestCase, NoCacheTestCase, TestCase):
                 'data_alerta': '2020-01-01T00:00:00Z',
                 'orgao': 0,
                 'id_alerta': 'id_alrt',
-                'dias_passados': -1
+                'dias_passados': -1,
+                'descricao': 'desc1',
+                'classe_hierarquia': 'classe1'
             }
         ]
 


### PR DESCRIPTION
Coloca ISPS nos helpers. Também adiciona as colunas "descricao" e "classe_hierarquia" utilizadas por esse alerta (que haviam sido removidas antes para agilizar a query no impala, já que elas não eram utilizadas).