### PR TITLE
Retira investigações que estão Fora da Instituição das contagens

### DIFF
--- a/dominio/suamesa/dao_functions.py
+++ b/dominio/suamesa/dao_functions.py
@@ -27,7 +27,7 @@ def get_tutela_investigacoes(orgao_id, request):
         392,                                # Inquérito Civil
         395                                 # Procedimento Preparatório
     ]
-    return Documento.investigacoes.em_curso(orgao_id, regras)
+    return Documento.investigacoes.em_curso(orgao_id, regras, remove_out=True)
 
 
 def get_tutela_processos(orgao_id, request):

--- a/dominio/suamesa/tests/test_dao_functions.py
+++ b/dominio/suamesa/tests/test_dao_functions.py
@@ -55,7 +55,8 @@ class TestSuaMesaFunctions(NoJWTTestCase, NoCacheTestCase, TestCase):
 
         self.assertEqual(output, 1)
         _Documento.investigacoes.em_curso.assert_called_once_with(
-            orgao_id, [51219, 51220, 51221, 51222, 51223, 392, 395]
+            orgao_id, [51219, 51220, 51221, 51222, 51223, 392, 395],
+            remove_out=True
         )
 
     @mock.patch('dominio.suamesa.dao_functions.Documento')


### PR DESCRIPTION
PAs, PPs e ICs que estão com situação "Fora da Instituição" não devem ser contados no Sua Mesa.