### PR TITLE
Feature/remove documentos arquivados

### DIFF
--- a/dominio/managers.py
+++ b/dominio/managers.py
@@ -15,6 +15,7 @@ from django.db.models import (
 
 class VistaManager(models.Manager):
     def __filter_inactive(self, qs, orgao_id):
+        # Import em escopo interno para evitar erros de loop de import
         from dominio.suamesa.dao import DocumentosArquivadosDAO
         docs_arquivados = set(DocumentosArquivadosDAO.get(orgao_id=orgao_id))
 

--- a/dominio/suamesa/dao.py
+++ b/dominio/suamesa/dao.py
@@ -182,7 +182,7 @@ class DocumentosArquivadosDAO(GenericDAO):
 
     @classmethod
     def serialize(cls, result_set):
-        return [r[0] for r in result_set]
+        return [int(r[0]) for r in result_set]
 
 
 class DocumentosArquivadosMultiplosOrgaosDAO(GenericDAO):
@@ -200,3 +200,7 @@ class DocumentosArquivadosMultiplosOrgaosDAO(GenericDAO):
         params = ",".join([f":id_orgao_{i}" for i in range(len(ids_orgaos))])
         query = cls.query().replace(":ids_orgaos", params)
         return impala_execute(query, prep_stat)
+
+    @classmethod
+    def serialize(cls, result_set):
+        return [int(r[0]) for r in result_set]

--- a/dominio/suamesa/dao.py
+++ b/dominio/suamesa/dao.py
@@ -8,6 +8,9 @@ Caso o tipo de dado não seja especificado, ou seja informado um tipo de dado
 não definido, o DAO irá levantar uma exceção.
 """
 
+from django.conf import settings
+
+from dominio.dao import GenericDAO
 from dominio.suamesa.exceptions import (
     APIInvalidSuaMesaType,
     APIMissingSuaMesaType,
@@ -169,3 +172,31 @@ class SuaMesaDetalheFactoryDAO(SuaMesaDAO):
 
         DAO = cls.switcher(tipo)
         return DAO.get(**kwargs)
+
+
+class DocumentosArquivadosDAO(GenericDAO):
+    QUERIES_DIR = settings.BASE_DIR.child("dominio", "suamesa", "queries")
+    query_file = "lista_documentos_arquivados.sql"
+    columns = ["docu_dk"]
+    table_namespaces = {"schema": settings.TABLE_NAMESPACE}
+
+    @classmethod
+    def serialize(cls, result_set):
+        return [r[0] for r in result_set]
+
+
+class DocumentosArquivadosMultiplosOrgaosDAO(GenericDAO):
+    QUERIES_DIR = settings.BASE_DIR.child("dominio", "suamesa", "queries")
+    query_file = "lista_documentos_arquivados_multiplos_orgaos.sql"
+    columns = ["docu_dk"]
+    table_namespaces = {"schema": settings.TABLE_NAMESPACE}
+
+    @classmethod
+    def execute(cls, **kwargs):
+        ids_orgaos = kwargs.get("ids_orgaos")
+        prep_stat = {f"id_orgao_{i}": v for i, v in enumerate(ids_orgaos)}
+        kwargs["ids_orgaos"] = prep_stat
+
+        params = ",".join([f":id_orgao_{i}" for i in range(len(ids_orgaos))])
+        query = cls.query().replace(":ids_orgaos", params)
+        return impala_execute(query, prep_stat)

--- a/dominio/suamesa/dao_functions.py
+++ b/dominio/suamesa/dao_functions.py
@@ -17,7 +17,7 @@ def get_vistas(orgao_id, request):
     if not cpf:
         e = "Parâmetro 'cpf' não foi dado!"
         raise APIMissingRequestParameterSuaMesa(e)
-    return Vista.vistas.abertas_promotor(orgao_id, cpf).count()
+    return Vista.vistas.abertas_promotor(orgao_id, cpf)
 
 
 def get_tutela_investigacoes(orgao_id, request):

--- a/dominio/suamesa/queries/lista_documentos_arquivados.sql
+++ b/dominio/suamesa/queries/lista_documentos_arquivados.sql
@@ -1,0 +1,3 @@
+SELECT docu_dk
+FROM {schema}.tb_documentos_arquivados
+WHERE docu_orgi_orga_dk_responsavel = :orgao_id

--- a/dominio/suamesa/queries/lista_documentos_arquivados_multiplos_orgaos.sql
+++ b/dominio/suamesa/queries/lista_documentos_arquivados_multiplos_orgaos.sql
@@ -1,0 +1,3 @@
+SELECT docu_dk
+FROM {schema}.tb_documentos_arquivados
+WHERE docu_orgi_orga_dk_responsavel in (:ids_orgaos)

--- a/dominio/suamesa/tests/test_dao_functions.py
+++ b/dominio/suamesa/tests/test_dao_functions.py
@@ -20,9 +20,7 @@ from dominio.suamesa.dao_functions import (
 class TestSuaMesaFunctions(NoJWTTestCase, NoCacheTestCase, TestCase):
     @mock.patch('dominio.suamesa.dao_functions.Vista')
     def test_get_vistas(self, _Vista):
-        manager_mock = mock.MagicMock()
-        manager_mock.count.return_value = 1
-        _Vista.vistas.abertas_promotor.return_value = manager_mock
+        _Vista.vistas.abertas_promotor.return_value = 1
 
         orgao_id = 10
         mock_request = mock.MagicMock()
@@ -34,7 +32,6 @@ class TestSuaMesaFunctions(NoJWTTestCase, NoCacheTestCase, TestCase):
         _Vista.vistas.abertas_promotor.assert_called_once_with(
             orgao_id, '1234'
         )
-        manager_mock.count.assert_called_once_with()
 
     def test_get_vistas_no_cpf(self):
         orgao_id = 10

--- a/dominio/tutela/tests/test_suamesa.py
+++ b/dominio/tutela/tests/test_suamesa.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 from dominio.tutela.suamesa import (
     get_regras,
     QUERY_REGRAS,
-    VISTAS_PAGE_SIZE,
 )
 
 from dominio.tests.testconf import NoJWTTestCase, NoCacheTestCase

--- a/dominio/tutela/tests/test_suamesa.py
+++ b/dominio/tutela/tests/test_suamesa.py
@@ -88,37 +88,25 @@ class TestSuaMesaDetalheVistas(NoJWTTestCase, NoCacheTestCase, TestCase):
 
 
 class TestSuaMesaListaVistasAbertas(NoJWTTestCase, NoCacheTestCase, TestCase):
-    @mock.patch('dominio.mixins.Paginator')
     @mock.patch('dominio.tutela.views.Vista')
-    def test_correct_response(self, _Vista, _Paginator):
-        page_mock = mock.MagicMock()
-        paginate_mock = mock.MagicMock()
-        manager_mock = mock.MagicMock()
-        orderby_mock = mock.MagicMock()
-        values_mock = mock.MagicMock()
-        paginator_response = [
+    def test_correct_response(self, _Vista):
+        response = [
             {
                 "numero_mprj": "1234",
                 "numero_externo": "tj1234",
                 "dt_abertura": date(2020, 1, 1),
                 "classe": "classe 1",
+                "docu_dk": "1"
             },
             {
                 "numero_mprj": "9012",
                 "numero_externo": "tj9012",
                 "dt_abertura": date(2018, 1, 1),
                 "classe": "classe 3",
+                "docu_dk": "2"
             },
         ]
-
-        page_mock.object_list = paginator_response
-        paginate_mock.page.return_value = page_mock
-        _Paginator.return_value = paginate_mock
-        values_mock.values.return_value = 'model response'
-        orderby_mock.order_by.return_value = values_mock
-        manager_mock.filter.return_value = orderby_mock
-
-        _Vista.vistas.abertas_por_data.return_value = manager_mock
+        _Vista.vistas.abertas_por_data.return_value = response
 
         expected = [
             {
@@ -138,19 +126,12 @@ class TestSuaMesaListaVistasAbertas(NoJWTTestCase, NoCacheTestCase, TestCase):
             'dominio:suamesa-lista-vistas',
             args=('1', '2', "trinta_mais")
         )
-        url += '?page=2'
+        url += '?page=1'
 
         resp = self.client.get(url)
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data, expected)
-        manager_mock.filter.assert_called_once_with(trinta_mais=1)
-        orderby_mock.order_by.assert_called_once_with('-data_abertura')
-        _Paginator.assert_called_once_with(
-            'model response',
-            VISTAS_PAGE_SIZE,
-        )
-        paginate_mock.page.assert_called_once_with(2)
 
     def test_return_404_for_incorrcect_data_abertura_value(self):
         url = reverse(

--- a/dominio/tutela/views.py
+++ b/dominio/tutela/views.py
@@ -1,9 +1,7 @@
 from django.db import connections
-from django.db.models import F
 from django.http import Http404
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
 
 from dominio.tutela import suamesa
 from dominio.mixins import CacheMixin, PaginatorMixin, JWTAuthMixin
@@ -84,21 +82,12 @@ class SuaMesaVistasListaView(
             msg = "data_abertura inválida. "\
                   f"Opções são: {', '.join(lista_aberturas)}"
             return Response(data=msg, status=404)
-
-        data = Vista.vistas.abertas_por_data(orgao_id, cpf).filter(
-            **{abertura: 1}
-        ).order_by('-data_abertura').values(
-            numero_mprj=F("documento__docu_nr_mp"),
-            numero_externo=F("documento__docu_nr_externo"),
-            dt_abertura=F("data_abertura"),
-            classe=F("documento__classe__descricao")
-        )
+        data = Vista.vistas.abertas_por_data(orgao_id, cpf, abertura)
         page_data = self.paginate(
             data,
             page=page,
             page_size=suamesa.VISTAS_PAGE_SIZE
         )
-
         vistas_lista = SuaMesaListaVistasSerializer(page_data, many=True).data
 
         return Response(data=vistas_lista)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ kazoo==2.8.0
 newrelic==5.4.0.132
 openpyxl==3.0.5
 psycopg2-binary
-pyjwt
+pyjwt==1.7.1
 pysolr==3.9.0
 python-dateutil==2.8.0
 python-decouple


### PR DESCRIPTION
Utiliza cache do Django para guardar a lista de vistas (já filtradas) para um determinado órgão e CPF. Essa lista cacheada será utilizada (caso esteja disponível) na caixinha de Vistas Abertas do Sua Mesa, no Detalhe do Sua Mesa (número de vistas abertas agregadas por intervalo de tempo), ou na Lista de Vistas Abertas.
Pelo resultado estar cacheado, não é necessário fazer uma chamada ao banco a cada request recebido.

A estrutura também é modificada para separar os cálculos em cima de querysets, e as chamadas feitas pelas Views. Assim, se quisermos modificar o comportamento de uma determinada View, a função correspondente pode ser modificada sem possivelmente afetar outras Views.
Isso também permite filtrar, a partir de dados do BDA, os resultados de um método "privado", e entregar os dados filtrados para a função da View correspondente fazer cálculos adicionais caso necessário (sem precisar filtrar pelos ids ativos diretamente no Oracle).