### PR TITLE
Recebe alerta_id como parâmetro da URL

### DIFF
--- a/dominio/alertas/serializers.py
+++ b/dominio/alertas/serializers.py
@@ -31,10 +31,6 @@ class AlertasComprasSerializer(serializers.Serializer):
     flag_dispensado = serializers.IntegerField()
 
 
-class IdentificadorAlertaSerializer(serializers.Serializer):
-    alerta_id = serializers.CharField()
-
-
 class AlertaOverlayPrescricaoSerializer(serializers.Serializer):
     tipo_penal = serializers.CharField()
     nm_investigado = serializers.CharField()

--- a/dominio/alertas/tests/test_alertas.py
+++ b/dominio/alertas/tests/test_alertas.py
@@ -250,9 +250,10 @@ class TestDispensarAlertas(NoJWTTestCase, TestCase):
     def setUp(self):
         super().setUp()
         self.orgao_id = "12345"
+        self.alerta_id = "AAA.abc123.12345"
         self.url = reverse(
             "dominio:dispensar_alerta",
-            args=(self.orgao_id,),
+            args=(self.orgao_id, self.alerta_id),
         )
 
         self.dispensa_patcher = mock.patch(
@@ -267,29 +268,23 @@ class TestDispensarAlertas(NoJWTTestCase, TestCase):
         self.dispensa_patcher.stop()
 
     def test_post_dispensa_alerta(self):
-        alerta_id = "AAA.abc123.12345"
-        self.url += f"?alerta_id={alerta_id}"
         resp = self.client.post(self.url)
 
         self.dispensa_controller_mock.assert_called_once_with(
-            self.orgao_id, alerta_id
+            self.orgao_id, self.alerta_id
         )
         self.controller_obj_mock.dispensa_para_orgao.assert_called_once_with()
         self.assertEqual(resp.status_code, 201)
-
-    def test_bad_request_missing_alerta_id(self):
-        resp = self.client.post(self.url)
-
-        self.assertEqual(resp.status_code, 400)
 
 
 class TestRetornaAlertas(NoJWTTestCase, TestCase):
     def setUp(self):
         super().setUp()
         self.orgao_id = "12345"
+        self.alerta_id = "AAA.abc123.12345"
         self.url = reverse(
             "dominio:retornar_alerta",
-            args=(self.orgao_id,),
+            args=(self.orgao_id, self.alerta_id),
         )
 
         self.dispensa_patcher = mock.patch(
@@ -304,20 +299,13 @@ class TestRetornaAlertas(NoJWTTestCase, TestCase):
         self.dispensa_patcher.stop()
 
     def test_post_retorna_alerta(self):
-        alerta_id = "AAA.abc123.12345"
-        self.url += f"?alerta_id={alerta_id}"
         resp = self.client.post(self.url)
 
         self.dispensa_controller_mock.assert_called_once_with(
-            self.orgao_id, alerta_id
+            self.orgao_id, self.alerta_id
         )
         self.controller_obj_mock.retorna_para_orgao.assert_called_once_with()
         self.assertEqual(resp.status_code, 200)
-
-    def test_bad_request_missing_alerta_id(self):
-        resp = self.client.post(self.url)
-
-        self.assertEqual(resp.status_code, 400)
 
 
 class AlertasOverlayTest(NoJWTTestCase, NoCacheTestCase, TestCase):
@@ -347,9 +335,10 @@ class TestEnviarAlertasComprasOuvidoria(NoJWTTestCase, TestCase):
 
         self.orgao_id = "12345"
         self.alerta_sigla = "COMP"
+        self.alerta_id = "abc12345"
         self.url = reverse(
             "dominio:alerta_ouvidoria",
-            args=(self.orgao_id, self.alerta_sigla)
+            args=(self.orgao_id, self.alerta_sigla, self.alerta_id)
         )
 
         self.controller_patcher = mock.patch(
@@ -368,18 +357,14 @@ class TestEnviarAlertasComprasOuvidoria(NoJWTTestCase, TestCase):
         self.controller_patcher.stop()
 
     def test_envia_alerta_compras_para_ouvidoria(self):
-        alerta_id = "abc12345"
-        self.url += f"?alerta_id={alerta_id}"
         resp = self.client.post(self.url)
 
         self.controller_obj_mock.envia.assert_called_once_with()
-        self.controller_mock.assert_called_once_with(self.orgao_id, alerta_id)
+        self.controller_mock.assert_called_once_with(
+            self.orgao_id,
+            self.alerta_id
+        )
         self.assertEqual(resp.status_code, self.status)
-
-    def test_bad_request_alerta_id_nao_informado(self):
-        resp = self.client.post(self.url)
-
-        self.assertEqual(resp.status_code, 400)
 
 
 class TestEnviarAlertasISPSOuvidoria(NoJWTTestCase, TestCase):
@@ -393,7 +378,7 @@ class TestEnviarAlertasISPSOuvidoria(NoJWTTestCase, TestCase):
 
         self.url = reverse(
             "dominio:alerta_ouvidoria",
-            args=(self.orgao_id, self.alerta_sigla)
+            args=(self.orgao_id, self.alerta_sigla, self.alerta_id)
         )
 
         self.controller_patcher = mock.patch(
@@ -412,7 +397,6 @@ class TestEnviarAlertasISPSOuvidoria(NoJWTTestCase, TestCase):
         self.controller_patcher.stop()
 
     def test_envia_alerta_compras_para_ouvidoria(self):
-        self.url += f"?alerta_id={self.alerta_id}"
         resp = self.client.post(self.url)
 
         self.controller_obj_mock.envia.assert_called_once_with()
@@ -422,14 +406,12 @@ class TestEnviarAlertasISPSOuvidoria(NoJWTTestCase, TestCase):
         )
         self.assertEqual(resp.status_code, self.status)
 
-    def test_bad_request_alerta_id_nao_informado(self):
-        resp = self.client.post(self.url)
-
-        self.assertEqual(resp.status_code, 400)
-
     def test_bad_request_alerta_sigla_invalida(self):
-        url = reverse("dominio:alerta_ouvidoria", args=(self.orgao_id, "AAA"))
-        url += f"?alerta_id={self.alerta_id}"
+        alerta_sigla = "AAA"
+        url = reverse(
+            "dominio:alerta_ouvidoria",
+            args=(self.orgao_id, alerta_sigla, self.alerta_id)
+        )
         resp = self.client.post(url)
 
         self.assertEqual(resp.status_code, 400)

--- a/dominio/alertas/urls.py
+++ b/dominio/alertas/urls.py
@@ -10,17 +10,17 @@ urlpatterns = [
         name='resumo_alertas'
     ),
     path(
-        "dispensar/<str:orgao_id>",
+        "dispensar/<str:orgao_id>/<str:alerta_id>",
         views.DispensarAlertaView.as_view(),
         name="dispensar_alerta"
     ),
     path(
-        "retornar/<str:orgao_id>",
+        "retornar/<str:orgao_id>/<str:alerta_id>",
         views.RetornarAlertaView.as_view(),
         name="retornar_alerta"
     ),
     path(
-        "ouvidoria/<str:orgao_id>/<str:sigla_alerta>",
+        "ouvidoria/<str:orgao_id>/<str:sigla_alerta>/<str:alerta_id>",
         views.EnviarAlertaOuvidoriaView.as_view(),
         name="alerta_ouvidoria"
     ),

--- a/dominio/alertas/views.py
+++ b/dominio/alertas/views.py
@@ -13,8 +13,6 @@ from dominio.alertas.exceptions import (
 )
 from dominio.permissions import PromotorOnlyPermission
 
-from .serializers import IdentificadorAlertaSerializer
-
 
 # TODO: criar um endpoint unificado?
 class AlertasView(JWTAuthMixin, PaginatorMixin, APIView):
@@ -62,15 +60,9 @@ class AlertasComprasView(JWTAuthMixin, PaginatorMixin, APIView):
 
 class DispensarAlertaView(JWTAuthMixin, APIView):
     # TODO: get_object que retorna 404 se alerta não existir
-
-    def get_alerta_id(self):
-        ser = IdentificadorAlertaSerializer(data=self.request.GET)
-        ser.is_valid(raise_exception=True)
-        return ser.validated_data["alerta_id"]
-
     def post(self, request, *args, **kwargs):
         orgao_id = self.kwargs.get(self.orgao_url_kwarg)
-        alerta_id = self.get_alerta_id()
+        alerta_id = self.kwargs.get("alerta_id")
 
         controller = DispensaAlertaController(
             orgao_id,
@@ -85,15 +77,9 @@ class DispensarAlertaView(JWTAuthMixin, APIView):
 
 class RetornarAlertaView(JWTAuthMixin, APIView):
     # TODO: get_object que retorna 404 se alerta não existir
-
-    def get_alerta_id(self):
-        ser = IdentificadorAlertaSerializer(data=self.request.GET)
-        ser.is_valid(raise_exception=True)
-        return ser.validated_data["alerta_id"]
-
     def post(self, request, *args, **kwargs):
         orgao_id = self.kwargs.get(self.orgao_url_kwarg)
-        alerta_id = self.get_alerta_id()
+        alerta_id = self.kwargs.get("alerta_id")
 
         controller = DispensaAlertaController(
             orgao_id,
@@ -131,15 +117,10 @@ class EnviarAlertaOuvidoriaView(JWTAuthMixin, APIView):
 
         return controllers[sigla_alerta]
 
-    def get_alerta_id(self):
-        ser = IdentificadorAlertaSerializer(data=self.request.GET)
-        ser.is_valid(raise_exception=True)
-        return ser.validated_data["alerta_id"]
-
     def post(self, request, *args, **kwargs):
         orgao_id = self.kwargs.get(self.orgao_url_kwarg)
         sigla_alerta = self.kwargs.get("sigla_alerta")
-        alerta_id = self.get_alerta_id()
+        alerta_id = self.kwargs.get("alerta_id")
 
         controller = self.controller_router(sigla_alerta)(
             orgao_id,


### PR DESCRIPTION
Altera o endpoint de dispensar, retornar alertas e enviar para a ouvidoria. Agora o `alerta_id` será informado na URL

 - `dominio/alertas/dispensar/<str:orgao_id>/<str:alerta_id>`
 -  `dominio/alertas/retornar/<str:orgao_id>/<str:alerta_id>`
 -  `dominio/alertas/ouvidoria/<str:orgao_id>/<str:sigla_alerta>/<str:alerta_id>`
